### PR TITLE
docs: fix freshrss callback url

### DIFF
--- a/docs/docs/client-examples/freshrss.md
+++ b/docs/docs/client-examples/freshrss.md
@@ -13,7 +13,7 @@ The following example variables are used, and should be replaced with your actua
 
 1. In Pocket ID create a new OIDC Client, name it, for example, `FreshRSS`.
 2. Set a logo for this OIDC Client if you would like to.
-3. Set the callback URL to: `https://freshrss.example.com`.
+3. Set the callback URL to: `https://freshrss.example.com/i/oidc/`.
 4. Copy the `Client ID`, `Client Secret`, and `OIDC Discovery URL` for use in the next steps.
 
 ## FreshRSS Setup


### PR DESCRIPTION
Fixed the callback url for FreshRSS in the docs. It was missing '/i/oidc', as referenced here https://freshrss.github.io/FreshRSS/en/admins/16_OpenID-Connect.html.