### PR TITLE
feat: update host configuration to allow external access

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,4 +7,4 @@ SQLITE_DB_PATH=data/pocket-id.db
 POSTGRES_CONNECTION_STRING=postgresql://postgres:postgres@localhost:5432/pocket-id
 UPLOAD_PATH=data/uploads
 PORT=8080
-HOST=localhost
+HOST=0.0.0.0

--- a/backend/internal/common/env_config.go
+++ b/backend/internal/common/env_config.go
@@ -35,7 +35,7 @@ var EnvConfig = &EnvConfigSchema{
 	UploadPath:               "data/uploads",
 	AppURL:                   "http://localhost",
 	Port:                     "8080",
-	Host:                     "localhost",
+	Host:                     "0.0.0.0",
 	MaxMindLicenseKey:        "",
 	GeoLiteDBPath:            "data/GeoLite2-City.mmdb",
 }


### PR DESCRIPTION
As discussed in #211, the backend now runs on 0.0.0.0 by default, and is overrideable through the `HOST` environment variable.