### PR TITLE
fix: user linking in ldap group sync

### DIFF
--- a/backend/internal/service/ldap_service.go
+++ b/backend/internal/service/ldap_service.go
@@ -106,7 +106,9 @@ func (s *LdapService) SyncGroups() error {
 			singleMember := strings.Split(strings.Split(member, "=")[1], ",")[0]
 
 			var databaseUser model.User
-			s.db.Where("username = ?", singleMember).First(&databaseUser)
+			// s.db.Where("username = ?", singleMember).First(&databaseUser)
+			s.db.Where("username = ?", singleMember).Where("ldap_id IS NOT NULL").First(&databaseUser)
+
 			membersUserId = append(membersUserId, databaseUser.ID)
 		}
 

--- a/backend/internal/service/ldap_service.go
+++ b/backend/internal/service/ldap_service.go
@@ -106,7 +106,6 @@ func (s *LdapService) SyncGroups() error {
 			singleMember := strings.Split(strings.Split(member, "=")[1], ",")[0]
 
 			var databaseUser model.User
-			// s.db.Where("username = ?", singleMember).First(&databaseUser)
 			s.db.Where("username = ?", singleMember).Where("ldap_id IS NOT NULL").First(&databaseUser)
 
 			membersUserId = append(membersUserId, databaseUser.ID)


### PR DESCRIPTION
Added a missed check for syncing ldap users into ldap groups. we were not checking for the ldap_id when trying to add user into the group which could cause a sync fail. 