### PR TITLE
feat: add support for TRUSTED_PROXIES environment variable

### DIFF
--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -28,6 +28,13 @@ func initRouter(db *gorm.DB, appConfigService *service.AppConfigService) {
 	r := gin.Default()
 	r.Use(gin.Logger())
 
+	if common.EnvConfig.TrustedProxies != nil && len(common.EnvConfig.TrustedProxies) > 0 {
+		r.ForwardedByClientIP = true
+		if err := r.SetTrustedProxies(common.EnvConfig.TrustedProxies); err != nil {
+			log.Fatalf("Unable to set trusted proxies: %s", err)
+		}
+	}
+
 	// Initialize services
 	emailService, err := service.NewEmailService(appConfigService, db)
 	if err != nil {

--- a/backend/internal/common/env_config.go
+++ b/backend/internal/common/env_config.go
@@ -19,6 +19,7 @@ const (
 type EnvConfigSchema struct {
 	AppEnv                   string     `env:"APP_ENV"`
 	AppURL                   string     `env:"PUBLIC_APP_URL"`
+	TrustedProxies           []string   `env:"TRUSTED_PROXIES"`
 	DbProvider               DbProvider `env:"DB_PROVIDER"`
 	SqliteDBPath             string     `env:"SQLITE_DB_PATH"`
 	PostgresConnectionString string     `env:"POSTGRES_CONNECTION_STRING"`
@@ -70,4 +71,6 @@ func init() {
 	if parsedAppUrl.Path != "" {
 		log.Fatal("PUBLIC_APP_URL must not contain a path")
 	}
+
+	// No need to validate TrustedProxies, it will do Gin
 }


### PR DESCRIPTION
Enable configuration of trusted proxies via a new `TRUSTED_PROXIES` env variable. Unfortunately Gin default ClientIP() logic very obscure. Should fix #263, will test it soon and update.