### PR TITLE
fix: pocket-id notify emails are considered as medium spam by rspamd

### DIFF
--- a/backend/internal/service/email_service.go
+++ b/backend/internal/service/email_service.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	ttemplate "text/template"
 	"time"
+	"github.com/google/uuid"
+	"strings"
 )
 
 type EmailService struct {
@@ -84,6 +86,22 @@ func SendEmail[V any](srv *EmailService, toEmail email.Address, template email.T
 	c.AddHeaderRaw("Content-Type",
 		fmt.Sprintf("multipart/alternative;\n boundary=%s;\n charset=UTF-8", boundary),
 	)
+
+	c.AddHeader("MIME-Version", "1.0")
+	c.AddHeader("Date", time.Now().Format(time.RFC1123Z))
+
+	// to create a message-id, we need the FQDN of the sending server, but that may be a docker hostname or localhost
+	// so we use the domain of the from address instead (the same as Thunderbird does)
+
+	from_address := srv.appConfigService.DbConfig.SmtpFrom.Value
+	if strings.Contains(from_address, "@" {
+		domain := strings.Split(from_address, "@")[1]
+	} else {
+		// this is completely wrong, but what else could we do?
+		domain := from_address
+	}
+	c.AddHeader("Message-ID", "<" + uuid.New().String() + "@" + domain + ">")
+
 	c.Body(body)
 
 	// Connect to the SMTP server

--- a/backend/internal/service/email_service.go
+++ b/backend/internal/service/email_service.go
@@ -94,11 +94,12 @@ func SendEmail[V any](srv *EmailService, toEmail email.Address, template email.T
 	// so we use the domain of the from address instead (the same as Thunderbird does)
 
 	from_address := srv.appConfigService.DbConfig.SmtpFrom.Value
-	if strings.Contains(from_address, "@" {
-		domain := strings.Split(from_address, "@")[1]
+	domain := ""
+	if strings.Contains(from_address, "@") {
+		domain = strings.Split(from_address, "@")[1]
 	} else {
 		// this is completely wrong, but what else could we do?
-		domain := from_address
+		domain = from_address
 	}
 	c.AddHeader("Message-ID", "<" + uuid.New().String() + "@" + domain + ">")
 

--- a/backend/internal/utils/email/composer.go
+++ b/backend/internal/utils/email/composer.go
@@ -45,7 +45,11 @@ func genAddressHeader(name string, addresses []Address, maxLength int) string {
 		} else {
 			email = fmt.Sprintf("<%s>", addr.Email)
 		}
-		writeHeaderQ(hl, addr.Name)
+		if isPrintableASCII(addr.Name) {
+			writeHeaderAtom(hl, addr.Name)
+		} else {
+			writeHeaderQ(hl, addr.Name)
+		}
 		writeHeaderAtom(hl, " ")
 		writeHeaderAtom(hl, email)
 	}


### PR DESCRIPTION
add additional mail headers and do not encode realnames when they are only 7bit ascii chars

Fixes: #330 
