### PR TITLE
fix: update profile picture URL to use dynamic user ID (#342)

### DIFF
--- a/frontend/src/lib/components/header/header-avatar.svelte
+++ b/frontend/src/lib/components/header/header-avatar.svelte
@@ -16,7 +16,7 @@
 <DropdownMenu.Root>
 	<DropdownMenu.Trigger
 		><Avatar.Root class="h-9 w-9">
-			<Avatar.Image src="/api/users/me/profile-picture.png" />
+			<Avatar.Image src={`/api/users/${$userStore?.id}/profile-picture.png`} />
 		</Avatar.Root></DropdownMenu.Trigger
 	>
 	<DropdownMenu.Content class="min-w-40" align="start">


### PR DESCRIPTION
This should fix a small bug created by a fix for #342.

The header profile picture now links to the User's ID instead of `me`