### PR TITLE
doc: update .env.example to reflect the new documentation location

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# See the README for more information: https://github.com/pocket-id/pocket-id?tab=readme-ov-file#environment-variables
+# See the documentation for more information: https://pocket-id.org/docs/configuration/environment-variables
 PUBLIC_APP_URL=http://localhost
 TRUST_PROXY=false
 MAXMIND_LICENSE_KEY=


### PR DESCRIPTION
The link in the example environment file didn't reflect the correct documentation link anymore