### PR TITLE
fix: ensure file descriptors are closed + other bugs

### DIFF
--- a/backend/internal/controller/user_controller.go
+++ b/backend/internal/controller/user_controller.go
@@ -250,6 +250,9 @@ func (uc *UserController) getUserProfilePictureHandler(c *gin.Context) {
 		_ = c.Error(err)
 		return
 	}
+	if picture != nil {
+		defer picture.Close()
+	}
 
 	c.Header("Cache-Control", "public, max-age=300")
 

--- a/backend/internal/job/file_cleanup_job.go
+++ b/backend/internal/job/file_cleanup_job.go
@@ -38,9 +38,9 @@ func (j *FileCleanupJobs) clearUnusedDefaultProfilePictures() error {
 	}
 
 	// Create a map to track which initials are in use
-	initialsInUse := make(map[string]bool)
+	initialsInUse := make(map[string]struct{})
 	for _, user := range users {
-		initialsInUse[user.Initials()] = true
+		initialsInUse[user.Initials()] = struct{}{}
 	}
 
 	defaultPicturesDir := common.EnvConfig.UploadPath + "/profile-pictures/defaults"
@@ -63,7 +63,7 @@ func (j *FileCleanupJobs) clearUnusedDefaultProfilePictures() error {
 		initials := strings.TrimSuffix(filename, ".png")
 
 		// If these initials aren't used by any user, delete the file
-		if !initialsInUse[initials] {
+		if _, ok := initialsInUse[initials]; !ok {
 			filePath := filepath.Join(defaultPicturesDir, filename)
 			if err := os.Remove(filePath); err != nil {
 				log.Printf("Failed to delete unused default profile picture %s: %v", filePath, err)

--- a/backend/internal/model/user.go
+++ b/backend/internal/model/user.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
 	datatype "github.com/pocket-id/pocket-id/backend/internal/model/types"
+	"github.com/pocket-id/pocket-id/backend/internal/utils"
 )
 
 type User struct {
@@ -66,14 +67,9 @@ func (u User) WebAuthnCredentialDescriptors() (descriptors []protocol.Credential
 func (u User) FullName() string { return u.FirstName + " " + u.LastName }
 
 func (u User) Initials() string {
-	initials := ""
-	if len(u.FirstName) > 0 {
-		initials += string(u.FirstName[0])
-	}
-	if len(u.LastName) > 0 {
-		initials += string(u.LastName[0])
-	}
-	return strings.ToUpper(initials)
+	return strings.ToUpper(
+		utils.GetFirstCharacter(u.FirstName) + utils.GetFirstCharacter(u.LastName),
+	)
 }
 
 type OneTimeAccessToken struct {

--- a/backend/internal/utils/string_util.go
+++ b/backend/internal/utils/string_util.go
@@ -102,3 +102,16 @@ func CamelCaseToScreamingSnakeCase(s string) string {
 	// Convert to uppercase
 	return strings.ToUpper(snake)
 }
+
+// GetFirstCharacter returns the first non-whitespace character of the string, correctly handling Unicode
+func GetFirstCharacter(str string) string {
+	for _, c := range str {
+		if unicode.IsSpace(c) {
+			continue
+		}
+		return string(c)
+	}
+
+	// Empty string case
+	return ""
+}

--- a/backend/internal/utils/string_util_test.go
+++ b/backend/internal/utils/string_util_test.go
@@ -103,3 +103,28 @@ func TestCamelCaseToSnakeCase(t *testing.T) {
 		})
 	}
 }
+
+func TestGetFirstCharacter(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty string", "", ""},
+		{"single character", "a", "a"},
+		{"multiple characters", "hello", "h"},
+		{"unicode character", "étoile", "é"},
+		{"special character", "!test", "!"},
+		{"number as first character", "123abc", "1"},
+		{"whitespace as first character", " hello", "h"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetFirstCharacter(tt.input)
+			if result != tt.expected {
+				t.Errorf("GetFirstCharacter(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
1. Ensures file descriptors are closed: changes in #406 meant that when reading the default picture, file descriptors would be left open
2. fixes ownership issue of the `defaultPicture` stream (previous code was potentially unsafe as the returned slice was valid only until the next buffer modification)
3. Fixes generation of initials when there are non-ASCII characters.

Fixup from #406