### PR TITLE
refactor: simplify app_config service and fix race conditions

### DIFF
--- a/.github/workflows/backend-linter.yml
+++ b/.github/workflows/backend-linter.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: backend/go.mod
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/pocket-id/pocket-id/backend
 
-go 1.23.7
+go 1.24
 
 require (
 	github.com/caarlos0/env/v11 v11.3.1

--- a/backend/internal/bootstrap/bootstrap.go
+++ b/backend/internal/bootstrap/bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	_ "github.com/golang-migrate/migrate/v4/source/file"
+
 	"github.com/pocket-id/pocket-id/backend/internal/service"
 )
 

--- a/backend/internal/controller/app_config_controller.go
+++ b/backend/internal/controller/app_config_controller.go
@@ -143,17 +143,17 @@ func (acc *AppConfigController) updateAppConfigHandler(c *gin.Context) {
 // @Success 200 {file} binary "Logo image"
 // @Router /api/application-configuration/logo [get]
 func (acc *AppConfigController) getLogoHandler(c *gin.Context) {
+	dbConfig := acc.appConfigService.GetDbConfig()
+
 	lightLogo, _ := strconv.ParseBool(c.DefaultQuery("light", "true"))
 
-	var imageName string
-	var imageType string
-
+	var imageName, imageType string
 	if lightLogo {
 		imageName = "logoLight"
-		imageType = acc.appConfigService.DbConfig.LogoLightImageType.Value
+		imageType = dbConfig.LogoLightImageType.Value
 	} else {
 		imageName = "logoDark"
-		imageType = acc.appConfigService.DbConfig.LogoDarkImageType.Value
+		imageType = dbConfig.LogoDarkImageType.Value
 	}
 
 	acc.getImage(c, imageName, imageType)
@@ -181,7 +181,7 @@ func (acc *AppConfigController) getFaviconHandler(c *gin.Context) {
 // @Failure 404 {object} object "{"error": "File not found"}"
 // @Router /api/application-configuration/background-image [get]
 func (acc *AppConfigController) getBackgroundImageHandler(c *gin.Context) {
-	imageType := acc.appConfigService.DbConfig.BackgroundImageType.Value
+	imageType := acc.appConfigService.GetDbConfig().BackgroundImageType.Value
 	acc.getImage(c, "background", imageType)
 }
 
@@ -196,17 +196,17 @@ func (acc *AppConfigController) getBackgroundImageHandler(c *gin.Context) {
 // @Security BearerAuth
 // @Router /api/application-configuration/logo [put]
 func (acc *AppConfigController) updateLogoHandler(c *gin.Context) {
+	dbConfig := acc.appConfigService.GetDbConfig()
+
 	lightLogo, _ := strconv.ParseBool(c.DefaultQuery("light", "true"))
 
-	var imageName string
-	var imageType string
-
+	var imageName, imageType string
 	if lightLogo {
 		imageName = "logoLight"
-		imageType = acc.appConfigService.DbConfig.LogoLightImageType.Value
+		imageType = dbConfig.LogoLightImageType.Value
 	} else {
 		imageName = "logoDark"
-		imageType = acc.appConfigService.DbConfig.LogoDarkImageType.Value
+		imageType = dbConfig.LogoDarkImageType.Value
 	}
 
 	acc.updateImage(c, imageName, imageType)
@@ -246,7 +246,7 @@ func (acc *AppConfigController) updateFaviconHandler(c *gin.Context) {
 // @Security BearerAuth
 // @Router /api/application-configuration/background-image [put]
 func (acc *AppConfigController) updateBackgroundImageHandler(c *gin.Context) {
-	imageType := acc.appConfigService.DbConfig.BackgroundImageType.Value
+	imageType := acc.appConfigService.GetDbConfig().BackgroundImageType.Value
 	acc.updateImage(c, "background", imageType)
 }
 

--- a/backend/internal/controller/app_config_controller.go
+++ b/backend/internal/controller/app_config_controller.go
@@ -60,11 +60,7 @@ type AppConfigController struct {
 // @Failure 500 {object} object "{"error": "error message"}"
 // @Router /application-configuration [get]
 func (acc *AppConfigController) listAppConfigHandler(c *gin.Context) {
-	configuration, err := acc.appConfigService.ListAppConfig(c.Request.Context(), false)
-	if err != nil {
-		_ = c.Error(err)
-		return
-	}
+	configuration := acc.appConfigService.ListAppConfig(false)
 
 	var configVariablesDto []dto.PublicAppConfigVariableDto
 	if err := dto.MapStructList(configuration, &configVariablesDto); err != nil {
@@ -85,11 +81,7 @@ func (acc *AppConfigController) listAppConfigHandler(c *gin.Context) {
 // @Security BearerAuth
 // @Router /application-configuration/all [get]
 func (acc *AppConfigController) listAllAppConfigHandler(c *gin.Context) {
-	configuration, err := acc.appConfigService.ListAppConfig(c.Request.Context(), true)
-	if err != nil {
-		_ = c.Error(err)
-		return
-	}
+	configuration := acc.appConfigService.ListAppConfig(true)
 
 	var configVariablesDto []dto.AppConfigVariableDto
 	if err := dto.MapStructList(configuration, &configVariablesDto); err != nil {

--- a/backend/internal/controller/e2etest_controller.go
+++ b/backend/internal/controller/e2etest_controller.go
@@ -36,7 +36,7 @@ func (tc *TestController) resetAndSeedHandler(c *gin.Context) {
 		return
 	}
 
-	if err := tc.TestService.ResetAppConfig(); err != nil {
+	if err := tc.TestService.ResetAppConfig(c.Request.Context()); err != nil {
 		_ = c.Error(err)
 		return
 	}

--- a/backend/internal/controller/user_controller.go
+++ b/backend/internal/controller/user_controller.go
@@ -227,7 +227,7 @@ func (uc *UserController) updateUserHandler(c *gin.Context) {
 // @Success 200 {object} dto.UserDto
 // @Router /api/users/me [put]
 func (uc *UserController) updateCurrentUserHandler(c *gin.Context) {
-	if !uc.appConfigService.DbConfig.AllowOwnAccountEdit.IsTrue() {
+	if !uc.appConfigService.GetDbConfig().AllowOwnAccountEdit.IsTrue() {
 		_ = c.Error(&common.AccountEditNotAllowedError{})
 		return
 	}
@@ -393,7 +393,7 @@ func (uc *UserController) exchangeOneTimeAccessTokenHandler(c *gin.Context) {
 		return
 	}
 
-	maxAge := int(uc.appConfigService.DbConfig.SessionDuration.AsDurationMinutes().Seconds())
+	maxAge := int(uc.appConfigService.GetDbConfig().SessionDuration.AsDurationMinutes().Seconds())
 	cookie.AddAccessTokenCookie(c, maxAge, token)
 
 	c.JSON(http.StatusOK, userDto)
@@ -418,7 +418,7 @@ func (uc *UserController) getSetupAccessTokenHandler(c *gin.Context) {
 		return
 	}
 
-	maxAge := int(uc.appConfigService.DbConfig.SessionDuration.AsDurationMinutes().Seconds())
+	maxAge := int(uc.appConfigService.GetDbConfig().SessionDuration.AsDurationMinutes().Seconds())
 	cookie.AddAccessTokenCookie(c, maxAge, token)
 
 	c.JSON(http.StatusOK, userDto)

--- a/backend/internal/controller/webauthn_controller.go
+++ b/backend/internal/controller/webauthn_controller.go
@@ -106,7 +106,7 @@ func (wc *WebauthnController) verifyLoginHandler(c *gin.Context) {
 		return
 	}
 
-	maxAge := int(wc.appConfigService.DbConfig.SessionDuration.AsDurationMinutes().Seconds())
+	maxAge := int(wc.appConfigService.GetDbConfig().SessionDuration.AsDurationMinutes().Seconds())
 	cookie.AddAccessTokenCookie(c, maxAge, token)
 
 	c.JSON(http.StatusOK, userDto)

--- a/backend/internal/dto/app_config_dto.go
+++ b/backend/internal/dto/app_config_dto.go
@@ -16,7 +16,7 @@ type AppConfigUpdateDto struct {
 	SessionDuration                    string `json:"sessionDuration" binding:"required"`
 	EmailsVerified                     string `json:"emailsVerified" binding:"required"`
 	AllowOwnAccountEdit                string `json:"allowOwnAccountEdit" binding:"required"`
-	SmtHost                            string `json:"smtpHost"`
+	SmtpHost                           string `json:"smtpHost"`
 	SmtpPort                           string `json:"smtpPort"`
 	SmtpFrom                           string `json:"smtpFrom" binding:"omitempty,email"`
 	SmtpUser                           string `json:"smtpUser"`

--- a/backend/internal/job/ldap_job.go
+++ b/backend/internal/job/ldap_job.go
@@ -34,7 +34,7 @@ func RegisterLdapJobs(ctx context.Context, ldapService *service.LdapService, app
 }
 
 func (j *LdapJobs) syncLdap(ctx context.Context) error {
-	if !j.appConfigService.DbConfig.LdapEnabled.IsTrue() {
+	if !j.appConfigService.GetDbConfig().LdapEnabled.IsTrue() {
 		return nil
 	}
 

--- a/backend/internal/model/app_config.go
+++ b/backend/internal/model/app_config.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -161,10 +162,22 @@ func (e AppConfigKeyNotFoundError) Error() string {
 	return fmt.Sprintf("cannot find config key '%s'", e.field)
 }
 
+func (e AppConfigKeyNotFoundError) Is(target error) bool {
+	// Ignore the field property when checking if an error is of the type AppConfigKeyNotFoundError
+	x := AppConfigKeyNotFoundError{}
+	return errors.As(target, &x)
+}
+
 type AppConfigInternalForbiddenError struct {
 	field string
 }
 
 func (e AppConfigInternalForbiddenError) Error() string {
 	return fmt.Sprintf("field '%s' is internal and can't be updated", e.field)
+}
+
+func (e AppConfigInternalForbiddenError) Is(target error) bool {
+	// Ignore the field property when checking if an error is of the type AppConfigInternalForbiddenError
+	x := AppConfigInternalForbiddenError{}
+	return errors.As(target, &x)
 }

--- a/backend/internal/model/app_config.go
+++ b/backend/internal/model/app_config.go
@@ -6,12 +6,8 @@ import (
 )
 
 type AppConfigVariable struct {
-	Key          string `gorm:"primaryKey;not null"`
-	Type         string
-	IsPublic     bool
-	IsInternal   bool
-	Value        string
-	DefaultValue string
+	Key   string `gorm:"primaryKey;not null"`
+	Value string
 }
 
 // IsTrue returns true if the value is a truthy string, such as "true", "t", "yes", "1", etc.
@@ -31,41 +27,41 @@ func (a *AppConfigVariable) AsDurationMinutes() time.Duration {
 
 type AppConfig struct {
 	// General
-	AppName             AppConfigVariable
-	SessionDuration     AppConfigVariable
-	EmailsVerified      AppConfigVariable
-	AllowOwnAccountEdit AppConfigVariable
+	AppName             AppConfigVariable `key:"appName,public"` // Public
+	SessionDuration     AppConfigVariable `key:"sessionDuration"`
+	EmailsVerified      AppConfigVariable `key:"emailsVerified"`
+	AllowOwnAccountEdit AppConfigVariable `key:"allowOwnAccountEdit,public"` // Public
 	// Internal
-	BackgroundImageType AppConfigVariable
-	LogoLightImageType  AppConfigVariable
-	LogoDarkImageType   AppConfigVariable
+	BackgroundImageType AppConfigVariable `key:"backgroundImageType,internal"`
+	LogoLightImageType  AppConfigVariable `key:"logoLightImageType,internal"`
+	LogoDarkImageType   AppConfigVariable `key:"logoDarkImageType,internal"`
 	// Email
-	SmtpHost                      AppConfigVariable
-	SmtpPort                      AppConfigVariable
-	SmtpFrom                      AppConfigVariable
-	SmtpUser                      AppConfigVariable
-	SmtpPassword                  AppConfigVariable
-	SmtpTls                       AppConfigVariable
-	SmtpSkipCertVerify            AppConfigVariable
-	EmailLoginNotificationEnabled AppConfigVariable
-	EmailOneTimeAccessEnabled     AppConfigVariable
+	SmtpHost                      AppConfigVariable `key:"smtpHost"`
+	SmtpPort                      AppConfigVariable `key:"smtpPort"`
+	SmtpFrom                      AppConfigVariable `key:"smtpFrom"`
+	SmtpUser                      AppConfigVariable `key:"smtpUser"`
+	SmtpPassword                  AppConfigVariable `key:"smtpPassword"`
+	SmtpTls                       AppConfigVariable `key:"smtpTls"`
+	SmtpSkipCertVerify            AppConfigVariable `key:"smtpSkipCertVerify"`
+	EmailLoginNotificationEnabled AppConfigVariable `key:"emailLoginNotificationEnabled"`
+	EmailOneTimeAccessEnabled     AppConfigVariable `key:"emailOneTimeAccessEnabled,public"` // Public
 	// LDAP
-	LdapEnabled                        AppConfigVariable
-	LdapUrl                            AppConfigVariable
-	LdapBindDn                         AppConfigVariable
-	LdapBindPassword                   AppConfigVariable
-	LdapBase                           AppConfigVariable
-	LdapUserSearchFilter               AppConfigVariable
-	LdapUserGroupSearchFilter          AppConfigVariable
-	LdapSkipCertVerify                 AppConfigVariable
-	LdapAttributeUserUniqueIdentifier  AppConfigVariable
-	LdapAttributeUserUsername          AppConfigVariable
-	LdapAttributeUserEmail             AppConfigVariable
-	LdapAttributeUserFirstName         AppConfigVariable
-	LdapAttributeUserLastName          AppConfigVariable
-	LdapAttributeUserProfilePicture    AppConfigVariable
-	LdapAttributeGroupMember           AppConfigVariable
-	LdapAttributeGroupUniqueIdentifier AppConfigVariable
-	LdapAttributeGroupName             AppConfigVariable
-	LdapAttributeAdminGroup            AppConfigVariable
+	LdapEnabled                        AppConfigVariable `key:"ldapEnabled,public"` // Public
+	LdapUrl                            AppConfigVariable `key:"ldapUrl"`
+	LdapBindDn                         AppConfigVariable `key:"ldapBindDn"`
+	LdapBindPassword                   AppConfigVariable `key:"ldapBindPassword"`
+	LdapBase                           AppConfigVariable `key:"ldapBase"`
+	LdapUserSearchFilter               AppConfigVariable `key:"ldapUserSearchFilter"`
+	LdapUserGroupSearchFilter          AppConfigVariable `key:"ldapUserGroupSearchFilter"`
+	LdapSkipCertVerify                 AppConfigVariable `key:"ldapSkipCertVerify"`
+	LdapAttributeUserUniqueIdentifier  AppConfigVariable `key:"ldapAttributeUserUniqueIdentifier"`
+	LdapAttributeUserUsername          AppConfigVariable `key:"ldapAttributeUserUsername"`
+	LdapAttributeUserEmail             AppConfigVariable `key:"ldapAttributeUserEmail"`
+	LdapAttributeUserFirstName         AppConfigVariable `key:"ldapAttributeUserFirstName"`
+	LdapAttributeUserLastName          AppConfigVariable `key:"ldapAttributeUserLastName"`
+	LdapAttributeUserProfilePicture    AppConfigVariable `key:"ldapAttributeUserProfilePicture"`
+	LdapAttributeGroupMember           AppConfigVariable `key:"ldapAttributeGroupMember"`
+	LdapAttributeGroupUniqueIdentifier AppConfigVariable `key:"ldapAttributeGroupUniqueIdentifier"`
+	LdapAttributeGroupName             AppConfigVariable `key:"ldapAttributeGroupName"`
+	LdapAttributeAdminGroup            AppConfigVariable `key:"ldapAttributeAdminGroup"`
 }

--- a/backend/internal/model/app_config_test.go
+++ b/backend/internal/model/app_config_test.go
@@ -1,10 +1,16 @@
-package model
+// We use model_test here to avoid an import cycle
+package model_test
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pocket-id/pocket-id/backend/internal/dto"
+	"github.com/pocket-id/pocket-id/backend/internal/model"
 )
 
 func TestAppConfigVariable_AsMinutesDuration(t *testing.T) {
@@ -48,7 +54,7 @@ func TestAppConfigVariable_AsMinutesDuration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configVar := AppConfigVariable{
+			configVar := model.AppConfigVariable{
 				Value: tt.value,
 			}
 
@@ -56,5 +62,68 @@ func TestAppConfigVariable_AsMinutesDuration(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 			assert.Equal(t, tt.expectedSeconds, int(result.Seconds()))
 		})
+	}
+}
+
+// This test ensures that the model.AppConfig and dto.AppConfigUpdateDto structs match:
+// - They should have the same properties, where the "json" tag of dto.AppConfigUpdateDto should match the "key" tag in model.AppConfig
+// - dto.AppConfigDto should not include "internal" fields from model.AppConfig
+// This test is primarily meant to catch discrepancies between the two structs as fields are added or removed over time
+func TestAppConfigStructMatchesUpdateDto(t *testing.T) {
+	appConfigType := reflect.TypeOf(model.AppConfig{})
+	updateDtoType := reflect.TypeOf(dto.AppConfigUpdateDto{})
+
+	// Process AppConfig fields
+	appConfigFields := make(map[string]string)
+	for i := 0; i < appConfigType.NumField(); i++ {
+		field := appConfigType.Field(i)
+		if field.Tag.Get("key") == "" {
+			// Skip internal fields
+			continue
+		}
+
+		// Extract the key name from the tag (takes the part before any comma)
+		keyTag := field.Tag.Get("key")
+		keyName, _, _ := strings.Cut(keyTag, ",")
+
+		appConfigFields[field.Name] = keyName
+	}
+
+	// Process AppConfigUpdateDto fields
+	dtoFields := make(map[string]string)
+	for i := 0; i < updateDtoType.NumField(); i++ {
+		field := updateDtoType.Field(i)
+
+		// Extract the json name from the tag (takes the part before any binding constraints)
+		jsonTag := field.Tag.Get("json")
+		jsonName, _, _ := strings.Cut(jsonTag, ",")
+
+		dtoFields[jsonName] = field.Name
+	}
+
+	// Verify every AppConfig field has a matching DTO field with the same name
+	for fieldName, keyName := range appConfigFields {
+		if strings.HasSuffix(fieldName, "ImageType") {
+			// Skip internal fields that shouldn't be in the DTO
+			continue
+		}
+
+		// Check if there's a DTO field with a matching JSON tag
+		_, exists := dtoFields[keyName]
+		assert.True(t, exists, "Field %s with key '%s' in AppConfig has no matching field in AppConfigUpdateDto", fieldName, keyName)
+	}
+
+	// Verify every DTO field has a matching AppConfig field
+	for jsonName, fieldName := range dtoFields {
+		// Find a matching field in AppConfig by key tag
+		found := false
+		for _, keyName := range appConfigFields {
+			if keyName == jsonName {
+				found = true
+				break
+			}
+		}
+
+		assert.True(t, found, "Field %s with json tag '%s' in AppConfigUpdateDto has no matching field in AppConfig", fieldName, jsonName)
 	}
 }

--- a/backend/internal/service/app_config_service.go
+++ b/backend/internal/service/app_config_service.go
@@ -130,6 +130,7 @@ func (s *AppConfigService) updateAppConfigUpdateDatabase(ctx context.Context, tx
 	err := tx.
 		WithContext(ctx).
 		Clauses(clause.OnConflict{
+			// Perform an "upsert" if the key already exists, replacing the value
 			Columns:   []clause.Column{{Name: "key"}},
 			DoUpdates: clause.AssignmentColumns([]string{"value"}),
 		}).

--- a/backend/internal/service/app_config_service.go
+++ b/backend/internal/service/app_config_service.go
@@ -28,8 +28,7 @@ type AppConfigService struct {
 
 func NewAppConfigService(ctx context.Context, db *gorm.DB) *AppConfigService {
 	service := &AppConfigService{
-		dbConfig: atomic.Pointer[model.AppConfig]{},
-		db:       db,
+		db: db,
 	}
 
 	err := service.LoadDbConfig(ctx)

--- a/backend/internal/service/app_config_service_test.go
+++ b/backend/internal/service/app_config_service_test.go
@@ -2,8 +2,16 @@ package service
 
 import (
 	"sync/atomic"
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 
 	"github.com/pocket-id/pocket-id/backend/internal/model"
+	"github.com/pocket-id/pocket-id/backend/internal/utils"
+	"github.com/stretchr/testify/require"
 )
 
 // NewTestAppConfigService is a function used by tests to create AppConfigService objects with pre-defined configuration values
@@ -14,4 +22,96 @@ func NewTestAppConfigService(config *model.AppConfig) *AppConfigService {
 	service.dbConfig.Store(config)
 
 	return service
+}
+
+func TestLoadDbConfig(t *testing.T) {
+	t.Run("empty config table", func(t *testing.T) {
+		db := newAppConfigTestDatabaseForTest(t)
+		service := &AppConfigService{
+			db: db,
+		}
+
+		// Load the config
+		err := service.LoadDbConfig(t.Context())
+		require.NoError(t, err)
+
+		// Config should be equal to default config
+		require.EqualValues(t, service.GetDbConfig(), service.getDefaultDbConfig())
+	})
+
+	t.Run("loads value from config table", func(t *testing.T) {
+		db := newAppConfigTestDatabaseForTest(t)
+
+		// Populate the config table with some initial values
+		err := db.
+			Create([]model.AppConfigVariable{
+				// Should be set to the default value because it's an empty string
+				{Key: "appName", Value: ""},
+				// Overrides default value
+				{Key: "sessionDuration", Value: "5"},
+				// Does not have a default value
+				{Key: "smtpHost", Value: "example"},
+			}).
+			Error
+		require.NoError(t, err)
+
+		// Load the config
+		service := &AppConfigService{
+			db: db,
+		}
+		err = service.LoadDbConfig(t.Context())
+		require.NoError(t, err)
+
+		// Values should match expected ones
+		expect := service.getDefaultDbConfig()
+		expect.SessionDuration.Value = "5"
+		expect.SmtpHost.Value = "example"
+		require.EqualValues(t, service.GetDbConfig(), expect)
+	})
+}
+
+// Implements gorm's logger.Writer interface
+type testLoggerAdapter struct {
+	t *testing.T
+}
+
+func (l testLoggerAdapter) Printf(format string, args ...any) {
+	l.t.Logf(format, args...)
+}
+
+func newAppConfigTestDatabaseForTest(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	// Get a name for this in-memory database that is specific to the test
+	dbName := utils.CreateSha256Hash(t.Name())
+
+	// Connect to a new in-memory SQL database
+	db, err := gorm.Open(
+		sqlite.Open("file:"+dbName+"?mode=memory&cache=shared"),
+		&gorm.Config{
+			TranslateError: true,
+			Logger: logger.New(
+				testLoggerAdapter{t: t},
+				logger.Config{
+					SlowThreshold:             200 * time.Millisecond,
+					LogLevel:                  logger.Info,
+					IgnoreRecordNotFoundError: false,
+					ParameterizedQueries:      false,
+					Colorful:                  false,
+				},
+			),
+		})
+	require.NoError(t, err, "Failed to connect to test database")
+
+	// Create the app_config_variables table
+	err = db.Exec(`
+CREATE TABLE app_config_variables
+(
+    key           VARCHAR(100) NOT NULL PRIMARY KEY,
+    value         TEXT NOT NULL
+)
+`).Error
+	require.NoError(t, err, "Failed to create test config table")
+
+	return db
 }

--- a/backend/internal/service/app_config_service_test.go
+++ b/backend/internal/service/app_config_service_test.go
@@ -1,0 +1,17 @@
+package service
+
+import (
+	"sync/atomic"
+
+	"github.com/pocket-id/pocket-id/backend/internal/model"
+)
+
+// NewTestAppConfigService is a function used by tests to create AppConfigService objects with pre-defined configuration values
+func NewTestAppConfigService(config *model.AppConfig) *AppConfigService {
+	service := &AppConfigService{
+		dbConfig: atomic.Pointer[model.AppConfig]{},
+	}
+	service.dbConfig.Store(config)
+
+	return service
+}

--- a/backend/internal/service/audit_log_service.go
+++ b/backend/internal/service/audit_log_service.go
@@ -72,7 +72,7 @@ func (s *AuditLogService) CreateNewSignInWithEmail(ctx context.Context, ipAddres
 	}
 
 	// If the user hasn't logged in from the same device before and email notifications are enabled, send an email
-	if s.appConfigService.DbConfig.EmailLoginNotificationEnabled.IsTrue() && count <= 1 {
+	if s.appConfigService.GetDbConfig().EmailLoginNotificationEnabled.IsTrue() && count <= 1 {
 		// We use a background context here as this is running in a goroutine
 		//nolint:contextcheck
 		go func() {

--- a/backend/internal/service/e2etest_service.go
+++ b/backend/internal/service/e2etest_service.go
@@ -300,19 +300,15 @@ func (s *TestService) ResetApplicationImages() error {
 	return nil
 }
 
-func (s *TestService) ResetAppConfig() error {
-	// Reseed the config variables
-	if err := s.appConfigService.InitDbConfig(context.Background()); err != nil {
-		return err
-	}
-
-	// Reset all app config variables to their default values
-	if err := s.db.Session(&gorm.Session{AllowGlobalUpdate: true}).Model(&model.AppConfigVariable{}).Update("value", "").Error; err != nil {
+func (s *TestService) ResetAppConfig(ctx context.Context) error {
+	// Reset all app config variables to their default values in the database
+	err := s.db.Session(&gorm.Session{AllowGlobalUpdate: true}).Model(&model.AppConfigVariable{}).Update("value", "").Error
+	if err != nil {
 		return err
 	}
 
 	// Reload the app config from the database after resetting the values
-	return s.appConfigService.LoadDbConfigFromDb()
+	return s.appConfigService.LoadDbConfig(ctx)
 }
 
 func (s *TestService) SetJWTKeys() {

--- a/backend/internal/service/jwt_service.go
+++ b/backend/internal/service/jwt_service.go
@@ -173,7 +173,7 @@ func (s *JwtService) GenerateAccessToken(user model.User) (string, error) {
 	now := time.Now()
 	token, err := jwt.NewBuilder().
 		Subject(user.ID).
-		Expiration(now.Add(s.appConfigService.DbConfig.SessionDuration.AsDurationMinutes())).
+		Expiration(now.Add(s.appConfigService.GetDbConfig().SessionDuration.AsDurationMinutes())).
 		IssuedAt(now).
 		Issuer(common.EnvConfig.AppURL).
 		Build()

--- a/backend/internal/service/jwt_service_test.go
+++ b/backend/internal/service/jwt_service_test.go
@@ -23,11 +23,9 @@ import (
 )
 
 func TestJwtService_Init(t *testing.T) {
-	mockConfig := &AppConfigService{
-		DbConfig: &model.AppConfig{
-			SessionDuration: model.AppConfigVariable{Value: "60"}, // 60 minutes
-		},
-	}
+	mockConfig := NewTestAppConfigService(&model.AppConfig{
+		SessionDuration: model.AppConfigVariable{Value: "60"}, // 60 minutes
+	})
 
 	t.Run("should generate new key when none exists", func(t *testing.T) {
 		// Create a temporary directory for the test
@@ -139,11 +137,9 @@ func TestJwtService_Init(t *testing.T) {
 }
 
 func TestJwtService_GetPublicJWK(t *testing.T) {
-	mockConfig := &AppConfigService{
-		DbConfig: &model.AppConfig{
-			SessionDuration: model.AppConfigVariable{Value: "60"}, // 60 minutes
-		},
-	}
+	mockConfig := NewTestAppConfigService(&model.AppConfig{
+		SessionDuration: model.AppConfigVariable{Value: "60"}, // 60 minutes
+	})
 
 	t.Run("returns public key when private key is initialized", func(t *testing.T) {
 		// Create a temporary directory for the test
@@ -273,11 +269,9 @@ func TestGenerateVerifyAccessToken(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Initialize the JWT service with a mock AppConfigService
-	mockConfig := &AppConfigService{
-		DbConfig: &model.AppConfig{
-			SessionDuration: model.AppConfigVariable{Value: "60"}, // 60 minutes
-		},
-	}
+	mockConfig := NewTestAppConfigService(&model.AppConfig{
+		SessionDuration: model.AppConfigVariable{Value: "60"}, // 60 minutes
+	})
 
 	// Setup the environment variable required by the token verification
 	originalAppURL := common.EnvConfig.AppURL
@@ -363,11 +357,9 @@ func TestGenerateVerifyAccessToken(t *testing.T) {
 
 	t.Run("uses session duration from config", func(t *testing.T) {
 		// Create a JWT service with a different session duration
-		customMockConfig := &AppConfigService{
-			DbConfig: &model.AppConfig{
-				SessionDuration: model.AppConfigVariable{Value: "30"}, // 30 minutes
-			},
-		}
+		customMockConfig := NewTestAppConfigService(&model.AppConfig{
+			SessionDuration: model.AppConfigVariable{Value: "30"}, // 30 minutes
+		})
 
 		service := &JwtService{}
 		err := service.init(customMockConfig, tempDir)
@@ -564,11 +556,9 @@ func TestGenerateVerifyIdToken(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Initialize the JWT service with a mock AppConfigService
-	mockConfig := &AppConfigService{
-		DbConfig: &model.AppConfig{
-			SessionDuration: model.AppConfigVariable{Value: "60"}, // 60 minutes
-		},
-	}
+	mockConfig := NewTestAppConfigService(&model.AppConfig{
+		SessionDuration: model.AppConfigVariable{Value: "60"}, // 60 minutes
+	})
 
 	// Setup the environment variable required by the token verification
 	originalAppURL := common.EnvConfig.AppURL
@@ -892,11 +882,9 @@ func TestGenerateVerifyOauthAccessToken(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Initialize the JWT service with a mock AppConfigService
-	mockConfig := &AppConfigService{
-		DbConfig: &model.AppConfig{
-			SessionDuration: model.AppConfigVariable{Value: "60"}, // 60 minutes
-		},
-	}
+	mockConfig := NewTestAppConfigService(&model.AppConfig{
+		SessionDuration: model.AppConfigVariable{Value: "60"}, // 60 minutes
+	})
 
 	// Setup the environment variable required by the token verification
 	originalAppURL := common.EnvConfig.AppURL

--- a/backend/internal/service/ldap_service.go
+++ b/backend/internal/service/ldap_service.go
@@ -32,12 +32,15 @@ func NewLdapService(db *gorm.DB, appConfigService *AppConfigService, userService
 }
 
 func (s *LdapService) createClient() (*ldap.Conn, error) {
-	if !s.appConfigService.DbConfig.LdapEnabled.IsTrue() {
+	dbConfig := s.appConfigService.GetDbConfig()
+
+	if !dbConfig.LdapEnabled.IsTrue() {
 		return nil, fmt.Errorf("LDAP is not enabled")
 	}
+
 	// Setup LDAP connection
-	ldapURL := s.appConfigService.DbConfig.LdapUrl.Value
-	skipTLSVerify := s.appConfigService.DbConfig.LdapSkipCertVerify.IsTrue()
+	ldapURL := dbConfig.LdapUrl.Value
+	skipTLSVerify := dbConfig.LdapSkipCertVerify.IsTrue()
 	client, err := ldap.DialURL(ldapURL, ldap.DialWithTLSConfig(&tls.Config{
 		InsecureSkipVerify: skipTLSVerify, //nolint:gosec
 	}))
@@ -46,8 +49,8 @@ func (s *LdapService) createClient() (*ldap.Conn, error) {
 	}
 
 	// Bind as service account
-	bindDn := s.appConfigService.DbConfig.LdapBindDn.Value
-	bindPassword := s.appConfigService.DbConfig.LdapBindPassword.Value
+	bindDn := dbConfig.LdapBindDn.Value
+	bindPassword := dbConfig.LdapBindPassword.Value
 	err = client.Bind(bindDn, bindPassword)
 	if err != nil {
 		return nil, fmt.Errorf("failed to bind to LDAP: %w", err)
@@ -80,6 +83,8 @@ func (s *LdapService) SyncAll(ctx context.Context) error {
 
 //nolint:gocognit
 func (s *LdapService) SyncGroups(ctx context.Context, tx *gorm.DB) error {
+	dbConfig := s.appConfigService.GetDbConfig()
+
 	// Setup LDAP connection
 	client, err := s.createClient()
 	if err != nil {
@@ -87,19 +92,20 @@ func (s *LdapService) SyncGroups(ctx context.Context, tx *gorm.DB) error {
 	}
 	defer client.Close()
 
-	baseDN := s.appConfigService.DbConfig.LdapBase.Value
-	nameAttribute := s.appConfigService.DbConfig.LdapAttributeGroupName.Value
-	uniqueIdentifierAttribute := s.appConfigService.DbConfig.LdapAttributeGroupUniqueIdentifier.Value
-	groupMemberOfAttribute := s.appConfigService.DbConfig.LdapAttributeGroupMember.Value
-	filter := s.appConfigService.DbConfig.LdapUserGroupSearchFilter.Value
-
 	searchAttrs := []string{
-		nameAttribute,
-		uniqueIdentifierAttribute,
-		groupMemberOfAttribute,
+		dbConfig.LdapAttributeGroupName.Value,
+		dbConfig.LdapAttributeGroupUniqueIdentifier.Value,
+		dbConfig.LdapAttributeGroupMember.Value,
 	}
 
-	searchReq := ldap.NewSearchRequest(baseDN, ldap.ScopeWholeSubtree, 0, 0, 0, false, filter, searchAttrs, []ldap.Control{})
+	searchReq := ldap.NewSearchRequest(
+		dbConfig.LdapBase.Value,
+		ldap.ScopeWholeSubtree,
+		0, 0, 0, false,
+		dbConfig.LdapUserGroupSearchFilter.Value,
+		searchAttrs,
+		[]ldap.Control{},
+	)
 	result, err := client.Search(searchReq)
 	if err != nil {
 		return fmt.Errorf("failed to query LDAP: %w", err)
@@ -111,11 +117,11 @@ func (s *LdapService) SyncGroups(ctx context.Context, tx *gorm.DB) error {
 	for _, value := range result.Entries {
 		var membersUserId []string
 
-		ldapId := value.GetAttributeValue(uniqueIdentifierAttribute)
+		ldapId := value.GetAttributeValue(dbConfig.LdapAttributeGroupUniqueIdentifier.Value)
 
 		// Skip groups without a valid LDAP ID
 		if ldapId == "" {
-			log.Printf("Skipping LDAP group without a valid unique identifier (attribute: %s)", uniqueIdentifierAttribute)
+			log.Printf("Skipping LDAP group without a valid unique identifier (attribute: %s)", dbConfig.LdapAttributeGroupUniqueIdentifier.Value)
 			continue
 		}
 
@@ -126,7 +132,7 @@ func (s *LdapService) SyncGroups(ctx context.Context, tx *gorm.DB) error {
 		tx.WithContext(ctx).Where("ldap_id = ?", ldapId).First(&databaseGroup)
 
 		// Get group members and add to the correct Group
-		groupMembers := value.GetAttributeValues(groupMemberOfAttribute)
+		groupMembers := value.GetAttributeValues(dbConfig.LdapAttributeGroupMember.Value)
 		for _, member := range groupMembers {
 			// Normal output of this would be CN=username,ou=people,dc=example,dc=com
 			// Splitting at the "=" and "," then just grabbing the username for that string
@@ -148,9 +154,9 @@ func (s *LdapService) SyncGroups(ctx context.Context, tx *gorm.DB) error {
 		}
 
 		syncGroup := dto.UserGroupCreateDto{
-			Name:         value.GetAttributeValue(nameAttribute),
-			FriendlyName: value.GetAttributeValue(nameAttribute),
-			LdapID:       value.GetAttributeValue(uniqueIdentifierAttribute),
+			Name:         value.GetAttributeValue(dbConfig.LdapAttributeGroupName.Value),
+			FriendlyName: value.GetAttributeValue(dbConfig.LdapAttributeGroupName.Value),
+			LdapID:       value.GetAttributeValue(dbConfig.LdapAttributeGroupUniqueIdentifier.Value),
 		}
 
 		if databaseGroup.ID == "" {
@@ -211,6 +217,8 @@ func (s *LdapService) SyncGroups(ctx context.Context, tx *gorm.DB) error {
 
 //nolint:gocognit
 func (s *LdapService) SyncUsers(ctx context.Context, tx *gorm.DB) error {
+	dbConfig := s.appConfigService.GetDbConfig()
+
 	// Setup LDAP connection
 	client, err := s.createClient()
 	if err != nil {
@@ -218,30 +226,27 @@ func (s *LdapService) SyncUsers(ctx context.Context, tx *gorm.DB) error {
 	}
 	defer client.Close()
 
-	baseDN := s.appConfigService.DbConfig.LdapBase.Value
-	uniqueIdentifierAttribute := s.appConfigService.DbConfig.LdapAttributeUserUniqueIdentifier.Value
-	usernameAttribute := s.appConfigService.DbConfig.LdapAttributeUserUsername.Value
-	emailAttribute := s.appConfigService.DbConfig.LdapAttributeUserEmail.Value
-	firstNameAttribute := s.appConfigService.DbConfig.LdapAttributeUserFirstName.Value
-	lastNameAttribute := s.appConfigService.DbConfig.LdapAttributeUserLastName.Value
-	profilePictureAttribute := s.appConfigService.DbConfig.LdapAttributeUserProfilePicture.Value
-	adminGroupAttribute := s.appConfigService.DbConfig.LdapAttributeAdminGroup.Value
-	filter := s.appConfigService.DbConfig.LdapUserSearchFilter.Value
-
 	searchAttrs := []string{
 		"memberOf",
 		"sn",
 		"cn",
-		uniqueIdentifierAttribute,
-		usernameAttribute,
-		emailAttribute,
-		firstNameAttribute,
-		lastNameAttribute,
-		profilePictureAttribute,
+		dbConfig.LdapAttributeUserUniqueIdentifier.Value,
+		dbConfig.LdapAttributeUserUsername.Value,
+		dbConfig.LdapAttributeUserEmail.Value,
+		dbConfig.LdapAttributeUserFirstName.Value,
+		dbConfig.LdapAttributeUserLastName.Value,
+		dbConfig.LdapAttributeUserProfilePicture.Value,
 	}
 
 	// Filters must start and finish with ()!
-	searchReq := ldap.NewSearchRequest(baseDN, ldap.ScopeWholeSubtree, 0, 0, 0, false, filter, searchAttrs, []ldap.Control{})
+	searchReq := ldap.NewSearchRequest(
+		dbConfig.LdapBase.Value,
+		ldap.ScopeWholeSubtree,
+		0, 0, 0, false,
+		dbConfig.LdapUserSearchFilter.Value,
+		searchAttrs,
+		[]ldap.Control{},
+	)
 
 	result, err := client.Search(searchReq)
 	if err != nil {
@@ -252,11 +257,11 @@ func (s *LdapService) SyncUsers(ctx context.Context, tx *gorm.DB) error {
 	ldapUserIDs := make(map[string]bool)
 
 	for _, value := range result.Entries {
-		ldapId := value.GetAttributeValue(uniqueIdentifierAttribute)
+		ldapId := value.GetAttributeValue(dbConfig.LdapAttributeUserUniqueIdentifier.Value)
 
 		// Skip users without a valid LDAP ID
 		if ldapId == "" {
-			log.Printf("Skipping LDAP user without a valid unique identifier (attribute: %s)", uniqueIdentifierAttribute)
+			log.Printf("Skipping LDAP user without a valid unique identifier (attribute: %s)", dbConfig.LdapAttributeUserUniqueIdentifier.Value)
 			continue
 		}
 
@@ -269,16 +274,16 @@ func (s *LdapService) SyncUsers(ctx context.Context, tx *gorm.DB) error {
 		// Check if user is admin by checking if they are in the admin group
 		isAdmin := false
 		for _, group := range value.GetAttributeValues("memberOf") {
-			if strings.Contains(group, adminGroupAttribute) {
+			if strings.Contains(group, dbConfig.LdapAttributeAdminGroup.Value) {
 				isAdmin = true
 			}
 		}
 
 		newUser := dto.UserCreateDto{
-			Username:  value.GetAttributeValue(usernameAttribute),
-			Email:     value.GetAttributeValue(emailAttribute),
-			FirstName: value.GetAttributeValue(firstNameAttribute),
-			LastName:  value.GetAttributeValue(lastNameAttribute),
+			Username:  value.GetAttributeValue(dbConfig.LdapAttributeUserUsername.Value),
+			Email:     value.GetAttributeValue(dbConfig.LdapAttributeUserEmail.Value),
+			FirstName: value.GetAttributeValue(dbConfig.LdapAttributeUserFirstName.Value),
+			LastName:  value.GetAttributeValue(dbConfig.LdapAttributeUserLastName.Value),
 			IsAdmin:   isAdmin,
 			LdapID:    ldapId,
 		}
@@ -296,7 +301,7 @@ func (s *LdapService) SyncUsers(ctx context.Context, tx *gorm.DB) error {
 		}
 
 		// Save profile picture
-		if pictureString := value.GetAttributeValue(profilePictureAttribute); pictureString != "" {
+		if pictureString := value.GetAttributeValue(dbConfig.LdapAttributeUserProfilePicture.Value); pictureString != "" {
 			if err := s.saveProfilePicture(ctx, databaseUser.ID, pictureString); err != nil {
 				log.Printf("Error saving profile picture for user %s: %v", newUser.Username, err)
 			}

--- a/backend/internal/service/oidc_service.go
+++ b/backend/internal/service/oidc_service.go
@@ -659,7 +659,7 @@ func (s *OidcService) getUserClaimsForClientInternal(ctx context.Context, userID
 
 	if slices.Contains(scopes, "email") {
 		claims["email"] = user.Email
-		claims["email_verified"] = s.appConfigService.DbConfig.EmailsVerified.IsTrue()
+		claims["email_verified"] = s.appConfigService.GetDbConfig().EmailsVerified.IsTrue()
 	}
 
 	if slices.Contains(scopes, "groups") {

--- a/backend/internal/service/user_group_service.go
+++ b/backend/internal/service/user_group_service.go
@@ -79,7 +79,7 @@ func (s *UserGroupService) Delete(ctx context.Context, id string) error {
 	}
 
 	// Disallow deleting the group if it is an LDAP group and LDAP is enabled
-	if group.LdapID != nil && s.appConfigService.DbConfig.LdapEnabled.IsTrue() {
+	if group.LdapID != nil && s.appConfigService.GetDbConfig().LdapEnabled.IsTrue() {
 		return &common.LdapUserGroupUpdateError{}
 	}
 
@@ -148,7 +148,7 @@ func (s *UserGroupService) updateInternal(ctx context.Context, id string, input 
 	}
 
 	// Disallow updating the group if it is an LDAP group and LDAP is enabled
-	if !allowLdapUpdate && group.LdapID != nil && s.appConfigService.DbConfig.LdapEnabled.IsTrue() {
+	if !allowLdapUpdate && group.LdapID != nil && s.appConfigService.GetDbConfig().LdapEnabled.IsTrue() {
 		return model.UserGroup{}, &common.LdapUserGroupUpdateError{}
 	}
 

--- a/backend/internal/service/user_service.go
+++ b/backend/internal/service/user_service.go
@@ -188,7 +188,7 @@ func (s *UserService) deleteUserInternal(ctx context.Context, userID string, all
 	}
 
 	// Disallow deleting the user if it is an LDAP user and LDAP is enabled
-	if !allowLdapDelete && user.LdapID != nil && s.appConfigService.DbConfig.LdapEnabled.IsTrue() {
+	if !allowLdapDelete && user.LdapID != nil && s.appConfigService.GetDbConfig().LdapEnabled.IsTrue() {
 		return &common.LdapUserUpdateError{}
 	}
 
@@ -278,7 +278,7 @@ func (s *UserService) updateUserInternal(ctx context.Context, userID string, upd
 	}
 
 	// Disallow updating the user if it is an LDAP group and LDAP is enabled
-	if !allowLdapUpdate && user.LdapID != nil && s.appConfigService.DbConfig.LdapEnabled.IsTrue() {
+	if !allowLdapUpdate && user.LdapID != nil && s.appConfigService.GetDbConfig().LdapEnabled.IsTrue() {
 		return model.User{}, &common.LdapUserUpdateError{}
 	}
 
@@ -314,7 +314,7 @@ func (s *UserService) RequestOneTimeAccessEmail(ctx context.Context, emailAddres
 		tx.Rollback()
 	}()
 
-	isDisabled := !s.appConfigService.DbConfig.EmailOneTimeAccessEnabled.IsTrue()
+	isDisabled := !s.appConfigService.GetDbConfig().EmailOneTimeAccessEnabled.IsTrue()
 	if isDisabled {
 		return &common.OneTimeAccessDisabledError{}
 	}

--- a/backend/internal/service/webauthn_service.go
+++ b/backend/internal/service/webauthn_service.go
@@ -26,7 +26,7 @@ type WebAuthnService struct {
 
 func NewWebAuthnService(db *gorm.DB, jwtService *JwtService, auditLogService *AuditLogService, appConfigService *AppConfigService) *WebAuthnService {
 	webauthnConfig := &webauthn.Config{
-		RPDisplayName: appConfigService.DbConfig.AppName.Value,
+		RPDisplayName: appConfigService.GetDbConfig().AppName.Value,
 		RPID:          utils.GetHostnameFromURL(common.EnvConfig.AppURL),
 		RPOrigins:     []string{common.EnvConfig.AppURL},
 		Timeouts: webauthn.TimeoutsConfig{
@@ -43,7 +43,13 @@ func NewWebAuthnService(db *gorm.DB, jwtService *JwtService, auditLogService *Au
 		},
 	}
 	wa, _ := webauthn.New(webauthnConfig)
-	return &WebAuthnService{db: db, webAuthn: wa, jwtService: jwtService, auditLogService: auditLogService, appConfigService: appConfigService}
+	return &WebAuthnService{
+		db:               db,
+		webAuthn:         wa,
+		jwtService:       jwtService,
+		auditLogService:  auditLogService,
+		appConfigService: appConfigService,
+	}
 }
 
 func (s *WebAuthnService) BeginRegistration(ctx context.Context, userID string) (*model.PublicKeyCredentialCreationOptions, error) {
@@ -314,5 +320,5 @@ func (s *WebAuthnService) UpdateCredential(ctx context.Context, userID, credenti
 
 // updateWebAuthnConfig updates the WebAuthn configuration with the app name as it can change during runtime
 func (s *WebAuthnService) updateWebAuthnConfig() {
-	s.webAuthn.Config.RPDisplayName = s.appConfigService.DbConfig.AppName.Value
+	s.webAuthn.Config.RPDisplayName = s.appConfigService.GetDbConfig().AppName.Value
 }

--- a/backend/resources/migrations/postgres/20250408120918_app_config_cols.down.sql
+++ b/backend/resources/migrations/postgres/20250408120918_app_config_cols.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE app_config_variables ADD type VARCHAR(20) NOT NULL,;
+ALTER TABLE app_config_variables ADD is_public BOOLEAN DEFAULT FALSE NOT NULL,;
+ALTER TABLE app_config_variables ADD is_internal BOOLEAN DEFAULT FALSE NOT NULL,;
+ALTER TABLE app_config_variables ADD default_value TEXT;

--- a/backend/resources/migrations/postgres/20250408120918_app_config_cols.up.sql
+++ b/backend/resources/migrations/postgres/20250408120918_app_config_cols.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE app_config_variables DROP type;
+ALTER TABLE app_config_variables DROP is_public;
+ALTER TABLE app_config_variables DROP is_internal;
+ALTER TABLE app_config_variables DROP default_value;

--- a/backend/resources/migrations/sqlite/20250408120918_app_config_cols.down.sql
+++ b/backend/resources/migrations/sqlite/20250408120918_app_config_cols.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE app_config_variables ADD type VARCHAR(20) NOT NULL,;
+ALTER TABLE app_config_variables ADD is_public BOOLEAN DEFAULT FALSE NOT NULL,;
+ALTER TABLE app_config_variables ADD is_internal BOOLEAN DEFAULT FALSE NOT NULL,;
+ALTER TABLE app_config_variables ADD default_value TEXT;

--- a/backend/resources/migrations/sqlite/20250408120918_app_config_cols.up.sql
+++ b/backend/resources/migrations/sqlite/20250408120918_app_config_cols.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE app_config_variables DROP type;
+ALTER TABLE app_config_variables DROP is_public;
+ALTER TABLE app_config_variables DROP is_internal;
+ALTER TABLE app_config_variables DROP default_value;


### PR DESCRIPTION
Fixes #391
Fixes #407 

As discussed with @stonith404 , this PR refactors the app_config service with the goals of greatly simplify the logic, and fixing race conditions.

There are significant performance improvements too, especially when updating config, as the number of database round-trips has been reduced to no more than 2 (currently, it's 2 per each key).

1. Stores the config object in-memory in an `atomic.Pointer`, which removes the risk of data races.
2. Ensures consistency when updating config in the database, by using a transaction and acquiring a table-level lock. This ensures that config is only written by a single goroutine.
3. Simplifies the data structures a lot. In particular, default values and attributes (such as marking fields as non-public) can are not stored in the database anymore, but only in the code. This reduces the complexity of keeping all data in-sync, since it wasn't necessary to have that info int eh DB.

PR includes extensive unit tests which use an in-memory SQLite database to validate the behavior of the service.

Note: I had to update to Go 1.24 to be able to use `testing.Context()`.