### PR TITLE
fix: improve LDAP error handling

### DIFF
--- a/backend/internal/common/errors.go
+++ b/backend/internal/common/errors.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 )
@@ -20,6 +21,12 @@ func (e *AlreadyInUseError) Error() string {
 	return e.Property + " is already in use"
 }
 func (e *AlreadyInUseError) HttpStatusCode() int { return 400 }
+
+func (e *AlreadyInUseError) Is(target error) bool {
+	// Ignore the field property when checking if an error is of the type AlreadyInUseError
+	x := &AlreadyInUseError{}
+	return errors.As(target, &x)
+}
 
 type SetupAlreadyCompletedError struct{}
 

--- a/backend/internal/controller/user_group_controller.go
+++ b/backend/internal/controller/user_group_controller.go
@@ -160,7 +160,7 @@ func (ugc *UserGroupController) update(c *gin.Context) {
 		return
 	}
 
-	group, err := ugc.UserGroupService.Update(c.Request.Context(), c.Param("id"), input, false)
+	group, err := ugc.UserGroupService.Update(c.Request.Context(), c.Param("id"), input)
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/backend/internal/service/ldap_service.go
+++ b/backend/internal/service/ldap_service.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/go-ldap/ldap/v3"
+	"github.com/pocket-id/pocket-id/backend/internal/common"
 	"github.com/pocket-id/pocket-id/backend/internal/dto"
 	"github.com/pocket-id/pocket-id/backend/internal/model"
 	"gorm.io/gorm"
@@ -28,7 +29,12 @@ type LdapService struct {
 }
 
 func NewLdapService(db *gorm.DB, appConfigService *AppConfigService, userService *UserService, groupService *UserGroupService) *LdapService {
-	return &LdapService{db: db, appConfigService: appConfigService, userService: userService, groupService: groupService}
+	return &LdapService{
+		db:               db,
+		appConfigService: appConfigService,
+		userService:      userService,
+		groupService:     groupService,
+	}
 }
 
 func (s *LdapService) createClient() (*ldap.Conn, error) {
@@ -39,19 +45,15 @@ func (s *LdapService) createClient() (*ldap.Conn, error) {
 	}
 
 	// Setup LDAP connection
-	ldapURL := dbConfig.LdapUrl.Value
-	skipTLSVerify := dbConfig.LdapSkipCertVerify.IsTrue()
-	client, err := ldap.DialURL(ldapURL, ldap.DialWithTLSConfig(&tls.Config{
-		InsecureSkipVerify: skipTLSVerify, //nolint:gosec
+	client, err := ldap.DialURL(dbConfig.LdapUrl.Value, ldap.DialWithTLSConfig(&tls.Config{
+		InsecureSkipVerify: dbConfig.LdapSkipCertVerify.IsTrue(), //nolint:gosec
 	}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to LDAP: %w", err)
 	}
 
 	// Bind as service account
-	bindDn := dbConfig.LdapBindDn.Value
-	bindPassword := dbConfig.LdapBindPassword.Value
-	err = client.Bind(bindDn, bindPassword)
+	err = client.Bind(dbConfig.LdapBindDn.Value, dbConfig.LdapBindPassword.Value)
 	if err != nil {
 		return nil, fmt.Errorf("failed to bind to LDAP: %w", err)
 	}
@@ -65,12 +67,19 @@ func (s *LdapService) SyncAll(ctx context.Context) error {
 		tx.Rollback()
 	}()
 
-	err := s.SyncUsers(ctx, tx)
+	// Setup LDAP connection
+	client, err := s.createClient()
+	if err != nil {
+		return fmt.Errorf("failed to create LDAP client: %w", err)
+	}
+	defer client.Close()
+
+	err = s.SyncUsers(ctx, tx, client)
 	if err != nil {
 		return fmt.Errorf("failed to sync users: %w", err)
 	}
 
-	err = s.SyncGroups(ctx, tx)
+	err = s.SyncGroups(ctx, tx, client)
 	if err != nil {
 		return fmt.Errorf("failed to sync groups: %w", err)
 	}
@@ -85,15 +94,8 @@ func (s *LdapService) SyncAll(ctx context.Context) error {
 }
 
 //nolint:gocognit
-func (s *LdapService) SyncGroups(ctx context.Context, tx *gorm.DB) error {
+func (s *LdapService) SyncGroups(ctx context.Context, tx *gorm.DB, client *ldap.Conn) error {
 	dbConfig := s.appConfigService.GetDbConfig()
-
-	// Setup LDAP connection
-	client, err := s.createClient()
-	if err != nil {
-		return fmt.Errorf("failed to create LDAP client: %w", err)
-	}
-	defer client.Close()
 
 	searchAttrs := []string{
 		dbConfig.LdapAttributeGroupName.Value,
@@ -115,11 +117,9 @@ func (s *LdapService) SyncGroups(ctx context.Context, tx *gorm.DB) error {
 	}
 
 	// Create a mapping for groups that exist
-	ldapGroupIDs := make(map[string]bool)
+	ldapGroupIDs := make(map[string]struct{}, len(result.Entries))
 
 	for _, value := range result.Entries {
-		var membersUserId []string
-
 		ldapId := value.GetAttributeValue(dbConfig.LdapAttributeGroupUniqueIdentifier.Value)
 
 		// Skip groups without a valid LDAP ID
@@ -128,29 +128,40 @@ func (s *LdapService) SyncGroups(ctx context.Context, tx *gorm.DB) error {
 			continue
 		}
 
-		ldapGroupIDs[ldapId] = true
+		ldapGroupIDs[ldapId] = struct{}{}
 
 		// Try to find the group in the database
 		var databaseGroup model.UserGroup
-		tx.WithContext(ctx).Where("ldap_id = ?", ldapId).First(&databaseGroup)
+		err = tx.
+			WithContext(ctx).
+			Where("ldap_id = ?", ldapId).
+			First(&databaseGroup).
+			Error
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			// This could error with ErrRecordNotFound and we want to ignore that here
+			return fmt.Errorf("failed to query for LDAP group ID '%s': %w", ldapId, err)
+		}
 
 		// Get group members and add to the correct Group
 		groupMembers := value.GetAttributeValues(dbConfig.LdapAttributeGroupMember.Value)
+		membersUserId := make([]string, 0, len(groupMembers))
 		for _, member := range groupMembers {
-			// Normal output of this would be CN=username,ou=people,dc=example,dc=com
-			// Splitting at the "=" and "," then just grabbing the username for that string
-			singleMember := strings.Split(strings.Split(member, "=")[1], ",")[0]
+			cn := getCN(member)
+			if cn == "" {
+				continue
+			}
 
 			var databaseUser model.User
-			err := tx.WithContext(ctx).Where("username = ? AND ldap_id IS NOT NULL", singleMember).First(&databaseUser).Error
-			if err != nil {
-				if errors.Is(err, gorm.ErrRecordNotFound) {
-					// The user collides with a non-LDAP user, so we skip it
-					continue
-				} else {
-					return err
-				}
-
+			err = tx.
+				WithContext(ctx).
+				Where("username = ? AND ldap_id IS NOT NULL", cn).
+				First(&databaseUser).
+				Error
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				// The user collides with a non-LDAP user, so we skip it
+				continue
+			} else if err != nil {
+				return fmt.Errorf("failed to query for existing user '%s': %w", cn, err)
 			}
 
 			membersUserId = append(membersUserId, databaseUser.ID)
@@ -165,26 +176,22 @@ func (s *LdapService) SyncGroups(ctx context.Context, tx *gorm.DB) error {
 		if databaseGroup.ID == "" {
 			newGroup, err := s.groupService.createInternal(ctx, syncGroup, tx)
 			if err != nil {
-				log.Printf("Error syncing group %s: %v", syncGroup.Name, err)
-				continue
+				return fmt.Errorf("failed to create group '%s': %w", syncGroup.Name, err)
 			}
 
 			_, err = s.groupService.updateUsersInternal(ctx, newGroup.ID, membersUserId, tx)
 			if err != nil {
-				log.Printf("Error syncing group %s: %v", syncGroup.Name, err)
-				continue
+				return fmt.Errorf("failed to sync users for group '%s': %w", syncGroup.Name, err)
 			}
 		} else {
 			_, err = s.groupService.updateInternal(ctx, databaseGroup.ID, syncGroup, true, tx)
 			if err != nil {
-				log.Printf("Error syncing group %s: %v", syncGroup.Name, err)
-				continue
+				return fmt.Errorf("failed to update group '%s': %w", syncGroup.Name, err)
 			}
 
 			_, err = s.groupService.updateUsersInternal(ctx, databaseGroup.ID, membersUserId, tx)
 			if err != nil {
-				log.Printf("Error syncing group %s: %v", syncGroup.Name, err)
-				continue
+				return fmt.Errorf("failed to sync users for group '%s': %w", syncGroup.Name, err)
 			}
 		}
 	}
@@ -197,37 +204,32 @@ func (s *LdapService) SyncGroups(ctx context.Context, tx *gorm.DB) error {
 		Select("ldap_id").
 		Error
 	if err != nil {
-		log.Printf("Failed to fetch groups from database: %v", err)
+		return fmt.Errorf("failed to fetch groups from database: %w", err)
 	}
 
 	// Delete groups that no longer exist in LDAP
 	for _, group := range ldapGroupsInDb {
-		if _, exists := ldapGroupIDs[*group.LdapID]; !exists {
-			err = tx.
-				WithContext(ctx).
-				Delete(&model.UserGroup{}, "ldap_id = ?", group.LdapID).
-				Error
-			if err != nil {
-				log.Printf("Failed to delete group %s with: %v", group.Name, err)
-			} else {
-				log.Printf("Deleted group %s", group.Name)
-			}
+		if _, exists := ldapGroupIDs[*group.LdapID]; exists {
+			continue
 		}
+
+		err = tx.
+			WithContext(ctx).
+			Delete(&model.UserGroup{}, "ldap_id = ?", group.LdapID).
+			Error
+		if err != nil {
+			return fmt.Errorf("failed to delete group '%s': %w", group.Name, err)
+		}
+
+		log.Printf("Deleted group '%s'", group.Name)
 	}
 
 	return nil
 }
 
 //nolint:gocognit
-func (s *LdapService) SyncUsers(ctx context.Context, tx *gorm.DB) error {
+func (s *LdapService) SyncUsers(ctx context.Context, tx *gorm.DB, client *ldap.Conn) error {
 	dbConfig := s.appConfigService.GetDbConfig()
-
-	// Setup LDAP connection
-	client, err := s.createClient()
-	if err != nil {
-		return fmt.Errorf("failed to create LDAP client: %w", err)
-	}
-	defer client.Close()
 
 	searchAttrs := []string{
 		"memberOf",
@@ -253,11 +255,11 @@ func (s *LdapService) SyncUsers(ctx context.Context, tx *gorm.DB) error {
 
 	result, err := client.Search(searchReq)
 	if err != nil {
-		fmt.Println(fmt.Errorf("failed to query LDAP: %w", err))
+		return fmt.Errorf("failed to query LDAP: %w", err)
 	}
 
 	// Create a mapping for users that exist
-	ldapUserIDs := make(map[string]bool)
+	ldapUserIDs := make(map[string]struct{}, len(result.Entries))
 
 	for _, value := range result.Entries {
 		ldapId := value.GetAttributeValue(dbConfig.LdapAttributeUserUniqueIdentifier.Value)
@@ -268,11 +270,19 @@ func (s *LdapService) SyncUsers(ctx context.Context, tx *gorm.DB) error {
 			continue
 		}
 
-		ldapUserIDs[ldapId] = true
+		ldapUserIDs[ldapId] = struct{}{}
 
 		// Get the user from the database
 		var databaseUser model.User
-		tx.WithContext(ctx).Where("ldap_id = ?", ldapId).First(&databaseUser)
+		err = tx.
+			WithContext(ctx).
+			Where("ldap_id = ?", ldapId).
+			First(&databaseUser).
+			Error
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			// This could error with ErrRecordNotFound and we want to ignore that here
+			return fmt.Errorf("failed to query for LDAP user ID '%s': %w", ldapId, err)
+		}
 
 		// Check if user is admin by checking if they are in the admin group
 		isAdmin := false
@@ -292,20 +302,29 @@ func (s *LdapService) SyncUsers(ctx context.Context, tx *gorm.DB) error {
 		}
 
 		if databaseUser.ID == "" {
-			_, err = s.userService.createUserInternal(ctx, newUser, tx)
-			if err != nil {
-				log.Printf("Error syncing user %s: %v", newUser.Username, err)
+			_, err = s.userService.createUserInternal(ctx, newUser, true, tx)
+			if errors.Is(err, &common.AlreadyInUseError{}) {
+				log.Printf("Skipping creating LDAP user '%s': %v", newUser.Username, err)
+				continue
+			} else if err != nil {
+				return fmt.Errorf("error creating user '%s': %w", newUser.Username, err)
 			}
 		} else {
 			_, err = s.userService.updateUserInternal(ctx, databaseUser.ID, newUser, false, true, tx)
-			if err != nil {
-				log.Printf("Error syncing user %s: %v", newUser.Username, err)
+			if errors.Is(err, &common.AlreadyInUseError{}) {
+				log.Printf("Skipping updating LDAP user '%s': %v", newUser.Username, err)
+				continue
+			} else if err != nil {
+				return fmt.Errorf("error updating user '%s': %w", newUser.Username, err)
 			}
 		}
 
 		// Save profile picture
-		if pictureString := value.GetAttributeValue(dbConfig.LdapAttributeUserProfilePicture.Value); pictureString != "" {
-			if err := s.saveProfilePicture(ctx, databaseUser.ID, pictureString); err != nil {
+		pictureString := value.GetAttributeValue(dbConfig.LdapAttributeUserProfilePicture.Value)
+		if pictureString != "" {
+			err = s.saveProfilePicture(ctx, databaseUser.ID, pictureString)
+			if err != nil {
+				// This is not a fatal error
 				log.Printf("Error saving profile picture for user %s: %v", newUser.Username, err)
 			}
 		}
@@ -319,18 +338,21 @@ func (s *LdapService) SyncUsers(ctx context.Context, tx *gorm.DB) error {
 		Select("ldap_id").
 		Error
 	if err != nil {
-		log.Printf("Failed to fetch users from database: %v", err)
+		return fmt.Errorf("failed to fetch users from database: %w", err)
 	}
 
 	// Delete users that no longer exist in LDAP
 	for _, user := range ldapUsersInDb {
-		if _, exists := ldapUserIDs[*user.LdapID]; !exists {
-			if err := s.userService.deleteUserInternal(ctx, user.ID, true, tx); err != nil {
-				log.Printf("Failed to delete user %s with: %v", user.Username, err)
-			} else {
-				log.Printf("Deleted user %s", user.Username)
-			}
+		if _, exists := ldapUserIDs[*user.LdapID]; exists {
+			continue
 		}
+
+		err = s.userService.deleteUserInternal(ctx, user.ID, true, tx)
+		if err != nil {
+			return fmt.Errorf("failed to delete user '%s': %w", user.Username, err)
+		}
+
+		log.Printf("Deleted user '%s'", user.Username)
 	}
 
 	return nil
@@ -367,9 +389,26 @@ func (s *LdapService) saveProfilePicture(parentCtx context.Context, userId strin
 	}
 
 	// Update the profile picture
-	if err := s.userService.UpdateProfilePicture(userId, reader); err != nil {
+	err = s.userService.UpdateProfilePicture(userId, reader)
+	if err != nil {
 		return fmt.Errorf("failed to update profile picture: %w", err)
 	}
 
 	return nil
+}
+
+// getCN returns the Common Name (CN) property from a LDAP identifier
+// See: https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ldap/distinguished-names
+func getCN(str string) string {
+	// Format is "CN=username,ou=people,dc=example,dc=com"
+	// First we split at the comma
+	for _, v := range strings.Split(str, ",") {
+		v = strings.TrimSpace(v)
+		if len(v) > 3 && strings.ToLower(v)[0:3] == "cn=" {
+			return v[3:]
+		}
+	}
+
+	// CN not found, return an empty string
+	return ""
 }

--- a/backend/internal/service/ldap_service_test.go
+++ b/backend/internal/service/ldap_service_test.go
@@ -4,59 +4,69 @@ import (
 	"testing"
 )
 
-func TestGetCN(t *testing.T) {
+func TestGetDNProperty(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		expected string
+		name           string
+		property       string
+		dn             string
+		expectedResult string
 	}{
 		{
-			name:     "valid CN in the beginning",
-			input:    "CN=username,OU=people,DC=example,DC=com",
-			expected: "username",
+			name:           "simple case",
+			property:       "cn",
+			dn:             "cn=username,ou=people,dc=example,dc=com",
+			expectedResult: "username",
 		},
 		{
-			name:     "lowercase cn",
-			input:    "cn=username,ou=people,dc=example,dc=com",
-			expected: "username",
+			name:           "property not found",
+			property:       "uid",
+			dn:             "cn=username,ou=people,dc=example,dc=com",
+			expectedResult: "",
 		},
 		{
-			name:     "no CN component",
-			input:    "UID=jsmith,OU=people,DC=example,DC=com",
-			expected: "",
+			name:           "mixed case property",
+			property:       "CN",
+			dn:             "cn=username,ou=people,dc=example,dc=com",
+			expectedResult: "username",
 		},
 		{
-			name:     "empty string",
-			input:    "",
-			expected: "",
+			name:           "mixed case DN",
+			property:       "cn",
+			dn:             "CN=username,OU=people,DC=example,DC=com",
+			expectedResult: "username",
 		},
 		{
-			name:     "CN with special characters",
-			input:    "CN=John Doe (Admin),OU=IT Staff,DC=example,DC=com",
-			expected: "John Doe (Admin)",
+			name:           "spaces in DN",
+			property:       "cn",
+			dn:             "cn=username, ou=people, dc=example, dc=com",
+			expectedResult: "username",
 		},
 		{
-			name:     "multiple CN components",
-			input:    "CN=username,CN=backup,OU=people,DC=example,DC=com",
-			expected: "username",
+			name:           "value with special characters",
+			property:       "cn",
+			dn:             "cn=user.name+123,ou=people,dc=example,dc=com",
+			expectedResult: "user.name+123",
 		},
 		{
-			name:     "CN with trailing spaces",
-			input:    "CN=username,OU=people,DC=example,DC=com",
-			expected: "username",
+			name:           "empty DN",
+			property:       "cn",
+			dn:             "",
+			expectedResult: "",
 		},
 		{
-			name:     "malformed DN without equals",
-			input:    "CNusername,OU=people,DC=example,DC=com",
-			expected: "",
+			name:           "empty property",
+			property:       "",
+			dn:             "cn=username,ou=people,dc=example,dc=com",
+			expectedResult: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getCN(tt.input)
-			if got != tt.expected {
-				t.Errorf("getCN(%q) = %q, want %q", tt.input, got, tt.expected)
+			result := getDNProperty(tt.property, tt.dn)
+			if result != tt.expectedResult {
+				t.Errorf("getDNProperty(%q, %q) = %q, want %q",
+					tt.property, tt.dn, result, tt.expectedResult)
 			}
 		})
 	}

--- a/backend/internal/service/ldap_service_test.go
+++ b/backend/internal/service/ldap_service_test.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"testing"
+)
+
+func TestGetCN(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "valid CN in the beginning",
+			input:    "CN=username,OU=people,DC=example,DC=com",
+			expected: "username",
+		},
+		{
+			name:     "lowercase cn",
+			input:    "cn=username,ou=people,dc=example,dc=com",
+			expected: "username",
+		},
+		{
+			name:     "no CN component",
+			input:    "UID=jsmith,OU=people,DC=example,DC=com",
+			expected: "",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "CN with special characters",
+			input:    "CN=John Doe (Admin),OU=IT Staff,DC=example,DC=com",
+			expected: "John Doe (Admin)",
+		},
+		{
+			name:     "multiple CN components",
+			input:    "CN=username,CN=backup,OU=people,DC=example,DC=com",
+			expected: "username",
+		},
+		{
+			name:     "CN with trailing spaces",
+			input:    "CN=username,OU=people,DC=example,DC=com",
+			expected: "username",
+		},
+		{
+			name:     "malformed DN without equals",
+			input:    "CNusername,OU=people,DC=example,DC=com",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getCN(tt.input)
+			if got != tt.expected {
+				t.Errorf("getCN(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR revises how errors are handled in the LDAP syncing service. I went through line-by-line to make sure that we treat errors consistently, and in most cases we should abort the sync and roll-back the changes in the DB (with some exceptions).

Should hopefully fix errors that were happening with syncing from LDAP, as some errors were simply logged while others causes failures.