### PR TITLE
fix: profile picture empty for users without first or last name

### DIFF
--- a/backend/internal/model/user.go
+++ b/backend/internal/model/user.go
@@ -67,9 +67,12 @@ func (u User) WebAuthnCredentialDescriptors() (descriptors []protocol.Credential
 func (u User) FullName() string { return u.FirstName + " " + u.LastName }
 
 func (u User) Initials() string {
-	return strings.ToUpper(
-		utils.GetFirstCharacter(u.FirstName) + utils.GetFirstCharacter(u.LastName),
-	)
+	first := utils.GetFirstCharacter(u.FirstName)
+	last := utils.GetFirstCharacter(u.LastName)
+	if first == "" && last == "" && len(u.Username) >= 2 {
+		return strings.ToUpper(u.Username[:2])
+	}
+	return strings.ToUpper(first + last)
 }
 
 type OneTimeAccessToken struct {


### PR DESCRIPTION
Fixes: https://github.com/pocket-id/pocket-id/issues/428

If no first or last name is found it uses the first two letters of the username to create the profile picture. 