### PR TITLE
Fix rootless Caddy data and configuration

### DIFF
--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -7,6 +7,11 @@ cd backend && ./pocket-id-backend &
 if [ "$CADDY_DISABLED" != "true" ]; then
   echo "Starting Caddy..."
 
+  # https://caddyserver.com/docs/conventions#data-directory
+  export XDG_DATA_HOME=/app/backend/data/.local/share
+  # https://caddyserver.com/docs/conventions#configuration-directory
+  export XDG_CONFIG_HOME=/app/backend/data/.config
+
   # Check if TRUST_PROXY is set to true and use the appropriate Caddyfile
   if [ "$TRUST_PROXY" = "true" ]; then
     caddy run --adapter caddyfile --config /etc/caddy/Caddyfile.trust-proxy &


### PR DESCRIPTION
Resolves the following errors when running rootless

<details><summary>Details</summary>
<p>


```json
[
  {
    "level": "error",
    "ts": 1745222697.0053172,
    "msg": "unable to create folder for config autosave",
    "dir": "/.config/caddy",
    "error": "mkdir /.config: permission denied"
  },
  {
    "level": "warn",
    "ts": 1745222697.0052032,
    "logger": "tls",
    "msg": "unable to get instance ID; storage clean stamps will be incomplete",
    "error": "mkdir /.local: permission denied"
  },
  {
    "level": "error",
    "ts": 1745222697.0056646,
    "logger": "tls",
    "msg": "could not clean default/global storage",
    "error": "unable to acquire storage_clean lock: creating lock file: open /.local/share/caddy/locks/storage_clean.lock: no such file or directory"
  }
]
```

</p>
</details> 