### PR TITLE
refactor: do not force redirects to happen on the server

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -2,3 +2,7 @@
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+
+# Compiled files
+.svelte-kit/
+build/

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -27,13 +27,11 @@ const authenticationHandle: Handle = async ({ event, resolve }) => {
 	const isPublicPath = ['/authorize', '/health'].includes(event.url.pathname);
 	const isAdminPath = event.url.pathname.startsWith('/settings/admin');
 
-	if (!isUnauthenticatedOnlyPath && !isPublicPath) {
-		if (!isSignedIn) {
-			return new Response(null, {
-				status: 302,
-				headers: { location: '/login' }
-			});
-		}
+	if (!isUnauthenticatedOnlyPath && !isPublicPath && !isSignedIn) {
+		return new Response(null, {
+			status: 302,
+			headers: { location: '/login' }
+		});
 	}
 
 	if (isUnauthenticatedOnlyPath && isSignedIn) {
@@ -81,7 +79,7 @@ function verifyJwt(accessToken: string | undefined) {
 		const jwtPayload = decodeJwt<{ isAdmin: boolean }>(accessToken);
 		if (jwtPayload?.exp && jwtPayload.exp * 1000 > Date.now()) {
 			isSignedIn = true;
-			isAdmin = jwtPayload?.isAdmin || false;
+			isAdmin = !!(jwtPayload?.isAdmin);
 		}
 	}
 

--- a/frontend/src/routes/+page.server.ts
+++ b/frontend/src/routes/+page.server.ts
@@ -1,6 +1,0 @@
-import { redirect } from '@sveltejs/kit';
-import type { PageServerLoad } from './$types';
-
-export const load: PageServerLoad = async () => {
-	return redirect(302, '/login');
-};

--- a/frontend/src/routes/+page.ts
+++ b/frontend/src/routes/+page.ts
@@ -1,0 +1,6 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async () => {
+	return redirect(302, '/login');
+};

--- a/frontend/src/routes/lc/+page.ts
+++ b/frontend/src/routes/lc/+page.ts
@@ -1,7 +1,8 @@
 import { redirect } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
 
 // Alias for /login/alternative/code
-export function GET({ url }) {
+export const load: PageLoad = async ({ url }) => {
 	let targetPath = '/login/alternative/code';
 	if (url.searchParams.has('redirect')) {
 		targetPath += `?redirect=${encodeURIComponent(url.searchParams.get('redirect')!)}`;

--- a/frontend/src/routes/lc/[code]/+page.ts
+++ b/frontend/src/routes/lc/[code]/+page.ts
@@ -1,7 +1,8 @@
 import { redirect } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
 
 // Alias for /login/alternative/code?code=...
-export function GET({ url, params }) {
+export const load: PageLoad = async ({ url, params }) => {
 	const targetPath = '/login/alternative/code';
 
 	const searchParams = new URLSearchParams();

--- a/frontend/src/routes/login/alternative/code/+page.ts
+++ b/frontend/src/routes/login/alternative/code/+page.ts
@@ -1,6 +1,6 @@
-import type { PageServerLoad } from './$types';
+import type { PageLoad } from './$types';
 
-export const load: PageServerLoad = async ({ url }) => {
+export const load: PageLoad = async ({ url }) => {
 	return {
 		code: url.searchParams.get('code'),
 		redirect: url.searchParams.get('redirect') || '/settings'

--- a/frontend/src/routes/login/alternative/email/+page.server.ts
+++ b/frontend/src/routes/login/alternative/email/+page.server.ts
@@ -1,7 +1,0 @@
-import type { PageServerLoad } from './$types';
-
-export const load: PageServerLoad = async ({ url }) => {
-	return {
-		redirect: url.searchParams.get('redirect') || undefined
-	};
-};

--- a/frontend/src/routes/login/alternative/email/+page.ts
+++ b/frontend/src/routes/login/alternative/email/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ url }) => {
+	return {
+		redirect: url.searchParams.get('redirect') || undefined
+	};
+};

--- a/frontend/src/routes/settings/+page.ts
+++ b/frontend/src/routes/settings/+page.ts
@@ -1,5 +1,6 @@
 import { redirect } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
 
-export function load() {
+export const load: PageLoad = async () => {
 	throw redirect(307, '/settings/account');
 }


### PR DESCRIPTION
Small refactor on the frontend: do not force redirects to happen on the server with `+page.server.ts`; use `+page.ts` instead, as they can happen on the client too