### PR TITLE
Tag container images with v{major}

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}},prefix=v
             type=semver,pattern={{major}}.{{minor}},prefix=v
+            type=semver,pattern={{major}},prefix=v
 
       - name: Install frontend dependencies
         working-directory: frontend


### PR DESCRIPTION
I'd like to enable auto-update on PocketID container, which would periodically fetch `v1` tag, and pull all the future releases, like `v1.0.1`, `v1.1.0`, `v1.3.7`, etc - any future releases up to a point when you cut the next `v2` with breaking changes.

Right now we have to either use `v1.0` and manually keep track of when `v1.1` gets released and manually updating the tag, or use `latest` and have the app break whenever the next major version is released.

Thanks!