### PR TITLE
feat: allow introspection endpoint to use Federated Client Credentials

### DIFF
--- a/backend/internal/controller/oidc_controller.go
+++ b/backend/internal/controller/oidc_controller.go
@@ -198,7 +198,7 @@ func (oc *OidcController) userInfoHandler(c *gin.Context) {
 		return
 	}
 
-	token, err := oc.jwtService.VerifyOauthAccessToken(authToken)
+	token, err := oc.jwtService.VerifyOAuthAccessToken(authToken)
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -306,9 +306,10 @@ func (oc *OidcController) introspectTokenHandler(c *gin.Context) {
 	// find valid tokens) while still allowing it to be used by an application that is
 	// supposed to interact with our IdP (since that needs to have a client_id
 	// and client_secret anyway).
-	clientID, clientSecret, _ := c.Request.BasicAuth()
+	var creds service.ClientAuthCredentials
+	creds.ClientID, creds.ClientSecret, _ = c.Request.BasicAuth()
 
-	response, err := oc.oidcService.IntrospectToken(c.Request.Context(), clientID, clientSecret, input.Token)
+	response, err := oc.oidcService.IntrospectToken(c.Request.Context(), creds, input.Token)
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/backend/internal/service/e2etest_service.go
+++ b/backend/internal/service/e2etest_service.go
@@ -479,6 +479,10 @@ func (s *TestService) SetLdapTestConfig(ctx context.Context) error {
 	return nil
 }
 
+func (s *TestService) SignRefreshToken(userID, clientID, refreshToken string) (string, error) {
+	return s.jwtService.GenerateOAuthRefreshToken(userID, clientID, refreshToken)
+}
+
 // GetExternalIdPJWKS returns the JWKS for the "external IdP".
 func (s *TestService) GetExternalIdPJWKS() (jwk.Set, error) {
 	pubKey, err := s.externalIdPKey.PublicKey()

--- a/backend/internal/service/jwt_service.go
+++ b/backend/internal/service/jwt_service.go
@@ -434,6 +434,27 @@ func (s *JwtService) VerifyOAuthRefreshToken(tokenString string) (userID, client
 	return userID, clientID, rt, nil
 }
 
+// GetTokenType returns the type of the JWT token issued by Pocket ID, but **does not validate it**.
+func (s *JwtService) GetTokenType(tokenString string) (string, error) {
+	// Disable validation and verification to parse the token without checking it
+	token, err := jwt.ParseString(
+		tokenString,
+		jwt.WithValidate(false),
+		jwt.WithVerify(false),
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse token: %w", err)
+	}
+
+	var tokenType string
+	err = token.Get(TokenTypeClaim, &tokenType)
+	if err != nil {
+		return "", fmt.Errorf("failed to get token type claim: %w", err)
+	}
+
+	return tokenType, nil
+}
+
 // GetPublicJWK returns the JSON Web Key (JWK) for the public key.
 func (s *JwtService) GetPublicJWK() (jwk.Key, error) {
 	if s.privateKey == nil {

--- a/backend/internal/service/jwt_service.go
+++ b/backend/internal/service/jwt_service.go
@@ -45,14 +45,14 @@ const (
 	// OAuthAccessTokenJWTType identifies a JWT as an OAuth access token
 	OAuthAccessTokenJWTType = "oauth-access-token" //nolint:gosec
 
+	// OAuthRefreshTokenJWTType identifies a JWT as an OAuth refresh token
+	OAuthRefreshTokenJWTType = "refresh-token"
+
 	// AccessTokenJWTType identifies a JWT as an access token used by Pocket ID
 	AccessTokenJWTType = "access-token"
 
 	// IDTokenJWTType identifies a JWT as an ID token used by Pocket ID
 	IDTokenJWTType = "id-token"
-
-	// RefreshTokenJWTType identifies a JWT as a refresh token used by Pocket ID
-	RefreshTokenJWTType = "refresh-token"
 
 	// Acceptable clock skew for verifying tokens
 	clockSkew = time.Minute
@@ -240,71 +240,6 @@ func (s *JwtService) VerifyAccessToken(tokenString string) (jwt.Token, error) {
 	return token, nil
 }
 
-func (s *JwtService) GenerateRefreshToken(user model.User, refreshToken string) (string, error) {
-	now := time.Now()
-	token, err := jwt.NewBuilder().
-		Subject(user.ID).
-		Expiration(now.Add(RefreshTokenDuration)).
-		IssuedAt(now).
-		Issuer(common.EnvConfig.AppURL).
-		Build()
-	if err != nil {
-		return "", fmt.Errorf("failed to build token: %w", err)
-	}
-
-	err = token.Set(RefreshTokenClaim, refreshToken)
-	if err != nil {
-		return "", fmt.Errorf("failed to set 'rt' claim in token: %w", err)
-	}
-
-	err = SetAudienceString(token, common.EnvConfig.AppURL)
-	if err != nil {
-		return "", fmt.Errorf("failed to set 'aud' claim in token: %w", err)
-	}
-
-	err = SetTokenType(token, RefreshTokenJWTType)
-	if err != nil {
-		return "", fmt.Errorf("failed to set 'type' claim in token: %w", err)
-	}
-
-	alg, _ := s.privateKey.Algorithm()
-	signed, err := jwt.Sign(token, jwt.WithKey(alg, s.privateKey))
-	if err != nil {
-		return "", fmt.Errorf("failed to sign token: %w", err)
-	}
-
-	return string(signed), nil
-}
-
-func (s *JwtService) VerifyRefreshToken(tokenString string) (userID string, rt string, err error) {
-	alg, _ := s.privateKey.Algorithm()
-	token, err := jwt.ParseString(
-		tokenString,
-		jwt.WithValidate(true),
-		jwt.WithKey(alg, s.privateKey),
-		jwt.WithAcceptableSkew(clockSkew),
-		jwt.WithAudience(common.EnvConfig.AppURL),
-		jwt.WithIssuer(common.EnvConfig.AppURL),
-		jwt.WithValidator(TokenTypeValidator(RefreshTokenJWTType)),
-	)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to parse token: %w", err)
-	}
-
-	err = token.Get(RefreshTokenClaim, &rt)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to get '%s' claim from token: %w", RefreshTokenClaim, err)
-	}
-
-	var ok bool
-	userID, ok = token.Subject()
-	if !ok {
-		return "", "", errors.New("failed to get 'sub' claim from token")
-	}
-
-	return userID, rt, nil
-}
-
 func (s *JwtService) GenerateIDToken(userClaims map[string]any, clientID string, nonce string) (string, error) {
 	now := time.Now()
 	token, err := jwt.NewBuilder().
@@ -428,6 +363,75 @@ func (s *JwtService) VerifyOAuthAccessToken(tokenString string) (jwt.Token, erro
 	}
 
 	return token, nil
+}
+
+func (s *JwtService) GenerateOAuthRefreshToken(userID string, clientID string, refreshToken string) (string, error) {
+	now := time.Now()
+	token, err := jwt.NewBuilder().
+		Subject(userID).
+		Expiration(now.Add(RefreshTokenDuration)).
+		IssuedAt(now).
+		Issuer(common.EnvConfig.AppURL).
+		Build()
+	if err != nil {
+		return "", fmt.Errorf("failed to build token: %w", err)
+	}
+
+	err = token.Set(RefreshTokenClaim, refreshToken)
+	if err != nil {
+		return "", fmt.Errorf("failed to set 'rt' claim in token: %w", err)
+	}
+
+	err = SetAudienceString(token, clientID)
+	if err != nil {
+		return "", fmt.Errorf("failed to set 'aud' claim in token: %w", err)
+	}
+
+	err = SetTokenType(token, OAuthRefreshTokenJWTType)
+	if err != nil {
+		return "", fmt.Errorf("failed to set 'type' claim in token: %w", err)
+	}
+
+	alg, _ := s.privateKey.Algorithm()
+	signed, err := jwt.Sign(token, jwt.WithKey(alg, s.privateKey))
+	if err != nil {
+		return "", fmt.Errorf("failed to sign token: %w", err)
+	}
+
+	return string(signed), nil
+}
+
+func (s *JwtService) VerifyOAuthRefreshToken(tokenString string) (userID, clientID, rt string, err error) {
+	alg, _ := s.privateKey.Algorithm()
+	token, err := jwt.ParseString(
+		tokenString,
+		jwt.WithValidate(true),
+		jwt.WithKey(alg, s.privateKey),
+		jwt.WithAcceptableSkew(clockSkew),
+		jwt.WithIssuer(common.EnvConfig.AppURL),
+		jwt.WithValidator(TokenTypeValidator(OAuthRefreshTokenJWTType)),
+	)
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to parse token: %w", err)
+	}
+
+	err = token.Get(RefreshTokenClaim, &rt)
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to get '%s' claim from token: %w", RefreshTokenClaim, err)
+	}
+
+	audiences, ok := token.Audience()
+	if !ok || len(audiences) != 1 || audiences[0] == "" {
+		return "", "", "", errors.New("failed to get 'aud' claim from token")
+	}
+	clientID = audiences[0]
+
+	userID, ok = token.Subject()
+	if !ok {
+		return "", "", "", errors.New("failed to get 'sub' claim from token")
+	}
+
+	return userID, clientID, rt, nil
 }
 
 // GetPublicJWK returns the JSON Web Key (JWK) for the public key.

--- a/backend/internal/service/jwt_service.go
+++ b/backend/internal/service/jwt_service.go
@@ -435,7 +435,7 @@ func (s *JwtService) VerifyOAuthRefreshToken(tokenString string) (userID, client
 }
 
 // GetTokenType returns the type of the JWT token issued by Pocket ID, but **does not validate it**.
-func (s *JwtService) GetTokenType(tokenString string) (string, error) {
+func (s *JwtService) GetTokenType(tokenString string) (string, jwt.Token, error) {
 	// Disable validation and verification to parse the token without checking it
 	token, err := jwt.ParseString(
 		tokenString,
@@ -443,16 +443,16 @@ func (s *JwtService) GetTokenType(tokenString string) (string, error) {
 		jwt.WithVerify(false),
 	)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse token: %w", err)
+		return "", nil, fmt.Errorf("failed to parse token: %w", err)
 	}
 
 	var tokenType string
 	err = token.Get(TokenTypeClaim, &tokenType)
 	if err != nil {
-		return "", fmt.Errorf("failed to get token type claim: %w", err)
+		return "", nil, fmt.Errorf("failed to get token type claim: %w", err)
 	}
 
-	return tokenType, nil
+	return tokenType, token, nil
 }
 
 // GetPublicJWK returns the JSON Web Key (JWK) for the public key.

--- a/backend/internal/service/jwt_service_test.go
+++ b/backend/internal/service/jwt_service_test.go
@@ -553,109 +553,6 @@ func TestGenerateVerifyAccessToken(t *testing.T) {
 	})
 }
 
-func TestGenerateVerifyRefreshToken(t *testing.T) {
-	// Create a temporary directory for the test
-	tempDir := t.TempDir()
-
-	// Initialize the JWT service with a mock AppConfigService
-	mockConfig := NewTestAppConfigService(&model.AppConfig{})
-
-	// Setup the environment variable required by the token verification
-	originalAppURL := common.EnvConfig.AppURL
-	common.EnvConfig.AppURL = "https://test.example.com"
-	defer func() {
-		common.EnvConfig.AppURL = originalAppURL
-	}()
-
-	t.Run("generates and verifies refresh token", func(t *testing.T) {
-		// Create a JWT service
-		service := &JwtService{}
-		err := service.init(mockConfig, tempDir)
-		require.NoError(t, err, "Failed to initialize JWT service")
-
-		// Create a test user
-		const (
-			userID       = "user123"
-			refreshToken = "rt-123"
-		)
-		user := model.User{
-			Base: model.Base{
-				ID: userID,
-			},
-		}
-
-		// Generate a token
-		tokenString, err := service.GenerateRefreshToken(user, refreshToken)
-		require.NoError(t, err, "Failed to generate refresh token")
-		assert.NotEmpty(t, tokenString, "Token should not be empty")
-
-		// Verify the token
-		resUser, resRT, err := service.VerifyRefreshToken(tokenString)
-		require.NoError(t, err, "Failed to verify generated token")
-		assert.Equal(t, userID, resUser, "Should return correct user ID")
-		assert.Equal(t, refreshToken, resRT, "Should return correct refresh token")
-	})
-
-	t.Run("fails verification for expired token", func(t *testing.T) {
-		// Create a JWT service
-		service := &JwtService{}
-		err := service.init(mockConfig, tempDir)
-		require.NoError(t, err, "Failed to initialize JWT service")
-
-		// Create a test user
-		user := model.User{
-			Base: model.Base{
-				ID: "user789",
-			},
-		}
-
-		// Generate a token using JWT directly to create an expired token
-		token, err := jwt.NewBuilder().
-			Subject(user.ID).
-			Expiration(time.Now().Add(-1 * time.Hour)). // Expired 1 hour ago
-			IssuedAt(time.Now().Add(-2 * time.Hour)).
-			Audience([]string{common.EnvConfig.AppURL}).
-			Issuer(common.EnvConfig.AppURL).
-			Build()
-		require.NoError(t, err, "Failed to build token")
-
-		signed, err := jwt.Sign(token, jwt.WithKey(jwa.RS256(), service.privateKey))
-		require.NoError(t, err, "Failed to sign token")
-
-		// Verify should fail due to expiration
-		_, _, err = service.VerifyRefreshToken(string(signed))
-		require.Error(t, err, "Verification should fail with expired token")
-		assert.Contains(t, err.Error(), `"exp" not satisfied`, "Error message should indicate token verification failure")
-	})
-
-	t.Run("fails verification with invalid signature", func(t *testing.T) {
-		// Create two JWT services with different keys
-		service1 := &JwtService{}
-		err := service1.init(mockConfig, t.TempDir())
-		require.NoError(t, err, "Failed to initialize first JWT service")
-
-		service2 := &JwtService{}
-		err = service2.init(mockConfig, t.TempDir())
-		require.NoError(t, err, "Failed to initialize second JWT service")
-
-		// Create a test user
-		user := model.User{
-			Base: model.Base{
-				ID: "user999",
-			},
-		}
-
-		// Generate a token with the first service
-		tokenString, err := service1.GenerateRefreshToken(user, "my-rt-123")
-		require.NoError(t, err, "Failed to generate refresh token")
-
-		// Verify with the second service should fail due to different keys
-		_, _, err = service2.VerifyRefreshToken(tokenString)
-		require.Error(t, err, "Verification should fail with invalid signature")
-		assert.Contains(t, err.Error(), "verification error", "Error message should indicate token verification failure")
-	})
-}
-
 func TestGenerateVerifyIdToken(t *testing.T) {
 	// Create a temporary directory for the test
 	tempDir := t.TempDir()
@@ -985,7 +882,7 @@ func TestGenerateVerifyIdToken(t *testing.T) {
 	})
 }
 
-func TestGenerateVerifyOauthAccessToken(t *testing.T) {
+func TestGenerateVerifyOAuthAccessToken(t *testing.T) {
 	// Create a temporary directory for the test
 	tempDir := t.TempDir()
 
@@ -1268,6 +1165,92 @@ func TestGenerateVerifyOauthAccessToken(t *testing.T) {
 		alg, ok := publicKey.Algorithm()
 		require.True(t, ok)
 		assert.Equal(t, jwa.RS256().String(), alg.String(), "Algorithm should be RS256")
+	})
+}
+
+func TestGenerateVerifyOAuthRefreshToken(t *testing.T) {
+	// Create a temporary directory for the test
+	tempDir := t.TempDir()
+
+	// Initialize the JWT service with a mock AppConfigService
+	mockConfig := NewTestAppConfigService(&model.AppConfig{})
+
+	// Setup the environment variable required by the token verification
+	originalAppURL := common.EnvConfig.AppURL
+	common.EnvConfig.AppURL = "https://test.example.com"
+	defer func() {
+		common.EnvConfig.AppURL = originalAppURL
+	}()
+
+	t.Run("generates and verifies refresh token", func(t *testing.T) {
+		// Create a JWT service
+		service := &JwtService{}
+		err := service.init(mockConfig, tempDir)
+		require.NoError(t, err, "Failed to initialize JWT service")
+
+		// Create a test user
+		const (
+			userID       = "user123"
+			clientID     = "client123"
+			refreshToken = "rt-123"
+		)
+
+		// Generate a token
+		tokenString, err := service.GenerateOAuthRefreshToken(userID, clientID, refreshToken)
+		require.NoError(t, err, "Failed to generate refresh token")
+		assert.NotEmpty(t, tokenString, "Token should not be empty")
+
+		// Verify the token
+		resUser, resClient, resRT, err := service.VerifyOAuthRefreshToken(tokenString)
+		require.NoError(t, err, "Failed to verify generated token")
+		assert.Equal(t, userID, resUser, "Should return correct user ID")
+		assert.Equal(t, clientID, resClient, "Should return correct client ID")
+		assert.Equal(t, refreshToken, resRT, "Should return correct refresh token")
+	})
+
+	t.Run("fails verification for expired token", func(t *testing.T) {
+		// Create a JWT service
+		service := &JwtService{}
+		err := service.init(mockConfig, tempDir)
+		require.NoError(t, err, "Failed to initialize JWT service")
+
+		// Generate a token using JWT directly to create an expired token
+		token, err := jwt.NewBuilder().
+			Subject("user789").
+			Expiration(time.Now().Add(-1 * time.Hour)). // Expired 1 hour ago
+			IssuedAt(time.Now().Add(-2 * time.Hour)).
+			Audience([]string{"client123"}).
+			Issuer(common.EnvConfig.AppURL).
+			Build()
+		require.NoError(t, err, "Failed to build token")
+
+		signed, err := jwt.Sign(token, jwt.WithKey(jwa.RS256(), service.privateKey))
+		require.NoError(t, err, "Failed to sign token")
+
+		// Verify should fail due to expiration
+		_, _, _, err = service.VerifyOAuthRefreshToken(string(signed))
+		require.Error(t, err, "Verification should fail with expired token")
+		assert.Contains(t, err.Error(), `"exp" not satisfied`, "Error message should indicate token verification failure")
+	})
+
+	t.Run("fails verification with invalid signature", func(t *testing.T) {
+		// Create two JWT services with different keys
+		service1 := &JwtService{}
+		err := service1.init(mockConfig, t.TempDir())
+		require.NoError(t, err, "Failed to initialize first JWT service")
+
+		service2 := &JwtService{}
+		err = service2.init(mockConfig, t.TempDir())
+		require.NoError(t, err, "Failed to initialize second JWT service")
+
+		// Generate a token with the first service
+		tokenString, err := service1.GenerateOAuthRefreshToken("user789", "client123", "my-rt-123")
+		require.NoError(t, err, "Failed to generate refresh token")
+
+		// Verify with the second service should fail due to different keys
+		_, _, _, err = service2.VerifyOAuthRefreshToken(tokenString)
+		require.Error(t, err, "Verification should fail with invalid signature")
+		assert.Contains(t, err.Error(), "verification error", "Error message should indicate token verification failure")
 	})
 }
 

--- a/backend/internal/service/oidc_service_test.go
+++ b/backend/internal/service/oidc_service_test.go
@@ -210,7 +210,7 @@ func TestOidcService_verifyClientCredentialsInternal(t *testing.T) {
 	t.Run("Confidential client", func(t *testing.T) {
 		t.Run("Succeeds with valid secret", func(t *testing.T) {
 			// Test with valid client credentials
-			client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, dto.OidcCreateTokensDto{
+			client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, ClientAuthCredentials{
 				ClientID:     confidentialClient.ID,
 				ClientSecret: confidentialSecret,
 			})
@@ -221,7 +221,7 @@ func TestOidcService_verifyClientCredentialsInternal(t *testing.T) {
 
 		t.Run("Fails with invalid secret", func(t *testing.T) {
 			// Test with invalid client secret
-			client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, dto.OidcCreateTokensDto{
+			client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, ClientAuthCredentials{
 				ClientID:     confidentialClient.ID,
 				ClientSecret: "invalid-secret",
 			})
@@ -232,7 +232,7 @@ func TestOidcService_verifyClientCredentialsInternal(t *testing.T) {
 
 		t.Run("Fails with missing secret", func(t *testing.T) {
 			// Test with missing client secret
-			client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, dto.OidcCreateTokensDto{
+			client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, ClientAuthCredentials{
 				ClientID: confidentialClient.ID,
 			})
 			require.Error(t, err)
@@ -245,7 +245,7 @@ func TestOidcService_verifyClientCredentialsInternal(t *testing.T) {
 	t.Run("Public client", func(t *testing.T) {
 		t.Run("Succeeds with no credentials", func(t *testing.T) {
 			// Public clients don't require client secret
-			client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, dto.OidcCreateTokensDto{
+			client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, ClientAuthCredentials{
 				ClientID: publicClient.ID,
 			})
 			require.NoError(t, err)
@@ -270,7 +270,7 @@ func TestOidcService_verifyClientCredentialsInternal(t *testing.T) {
 			require.NoError(t, err)
 
 			// Test with valid JWT assertion
-			client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, dto.OidcCreateTokensDto{
+			client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, ClientAuthCredentials{
 				ClientID:            federatedClient.ID,
 				ClientAssertionType: ClientAssertionTypeJWTBearer,
 				ClientAssertion:     string(signedToken),
@@ -282,7 +282,7 @@ func TestOidcService_verifyClientCredentialsInternal(t *testing.T) {
 
 		t.Run("Fails with malformed JWT", func(t *testing.T) {
 			// Test with invalid JWT assertion (just a random string)
-			client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, dto.OidcCreateTokensDto{
+			client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, ClientAuthCredentials{
 				ClientID:            federatedClient.ID,
 				ClientAssertionType: ClientAssertionTypeJWTBearer,
 				ClientAssertion:     "invalid.jwt.token",
@@ -311,7 +311,7 @@ func TestOidcService_verifyClientCredentialsInternal(t *testing.T) {
 				require.NoError(t, err)
 
 				// Test with invalid JWT assertion
-				client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, dto.OidcCreateTokensDto{
+				client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, ClientAuthCredentials{
 					ClientID:            federatedClient.ID,
 					ClientAssertionType: ClientAssertionTypeJWTBearer,
 					ClientAssertion:     string(signedToken),
@@ -352,7 +352,7 @@ func TestOidcService_verifyClientCredentialsInternal(t *testing.T) {
 			require.NoError(t, err)
 
 			// Test with valid JWT assertion
-			client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, dto.OidcCreateTokensDto{
+			client, err := s.verifyClientCredentialsInternal(t.Context(), s.db, ClientAuthCredentials{
 				ClientID:            federatedClient.ID,
 				ClientAssertionType: ClientAssertionTypeJWTBearer,
 				ClientAssertion:     string(signedToken),

--- a/tests/data.ts
+++ b/tests/data.ts
@@ -87,11 +87,13 @@ export const refreshTokens = [
 	{
 		token: 'ou87UDg249r1StBLYkMEqy9TXDbV5HmGuDpMcZDo',
 		clientId: oidcClients.nextcloud.id,
+		userId: 'f4b89dc2-62fb-46bf-9f5f-c34f4eafe93e',
 		expired: false
 	},
 	{
 		token: 'X4vqwtRyCUaq51UafHea4Fsg8Km6CAns6vp3tuX4',
 		clientId: oidcClients.nextcloud.id,
+		userId: 'f4b89dc2-62fb-46bf-9f5f-c34f4eafe93e',
 		expired: true
 	}
 ];

--- a/tests/specs/oidc.spec.ts
+++ b/tests/specs/oidc.spec.ts
@@ -355,7 +355,18 @@ test.describe("Introspection endpoint", () => {
   });
 
   test("non-expired refresh_token can be verified", async ({ request }) => {
-    const { token } = refreshTokens.filter((token) => !token.expired)[0];
+    const { token, clientId, userId } = refreshTokens.filter(
+      (token) => !token.expired
+    )[0];
+
+    // Sign the refresh token
+    const refreshToken = await request.post("/api/test/refreshtoken", {
+      data: {
+        rt: token,
+        client: clientId,
+        user: userId,
+      }
+    }).then((r) => r.text())
 
     const introspectionResponse = await request.post("/api/oidc/introspect", {
       headers: {
@@ -365,7 +376,7 @@ test.describe("Introspection endpoint", () => {
           Buffer.from(`${client.id}:${client.secret}`).toString("base64"),
       },
       form: {
-        token: token,
+        token: refreshToken,
       },
     });
 
@@ -376,7 +387,18 @@ test.describe("Introspection endpoint", () => {
   });
 
   test("expired refresh_token can be verified", async ({ request }) => {
-    const { token } = refreshTokens.filter((token) => token.expired)[0];
+    const { token, clientId, userId } = refreshTokens.filter(
+      (token) => token.expired
+    )[0];
+
+    // Sign the refresh token
+    const refreshToken = await request.post("/api/test/refreshtoken", {
+      data: {
+        rt: token,
+        client: clientId,
+        user: userId,
+      }
+    }).then((r) => r.text())
 
     const introspectionResponse = await request.post("/api/oidc/introspect", {
       headers: {
@@ -386,7 +408,7 @@ test.describe("Introspection endpoint", () => {
           Buffer.from(`${client.id}:${client.secret}`).toString("base64"),
       },
       form: {
-        token: token,
+        token: refreshToken,
       },
     });
 

--- a/tests/specs/oidc.spec.ts
+++ b/tests/specs/oidc.spec.ts
@@ -405,6 +405,7 @@ test.describe("Introspection endpoint", () => {
   });
 
   test("fails with federated credentials for wrong app", async ({
+    page,
     request,
   }) => {
     const validAccessToken = await generateOauthAccessToken(


### PR DESCRIPTION
Follow-up from #566 to complete the work started there

- Add support for using federated client credentials for the introspection endpoint, to validate auth and refresh tokens. Calls to the endpoint use `Authorization: Bearer <jwt>` for authorization.
- As part of that change, and for other reasons discussed on Discord, the refresh token's format has changed, and it's now a JWT containing the actual refresh code (stored in the DB, hashed), plus the ID of the client that uses it and the ID of the user it belongs to
   - This is required because otherwise there's no way to know the client ID when introspecting a refresh token using federated client credentials
   - It also allows more careful database lookups
   - The RFC doesn't mandate anything about the format of refresh tokens, which are opaque strings for clients, so this remains fully-compliant
