### PR TITLE
feat: allow setting unix socket mode

### DIFF
--- a/backend/internal/common/env_config.go
+++ b/backend/internal/common/env_config.go
@@ -33,6 +33,7 @@ type EnvConfigSchema struct {
 	Port               string     `env:"PORT"`
 	Host               string     `env:"HOST"`
 	UnixSocket         string     `env:"UNIX_SOCKET"`
+	UnixSocketMode     string     `env:"UNIX_SOCKET_MODE"`
 	MaxMindLicenseKey  string     `env:"MAXMIND_LICENSE_KEY"`
 	GeoLiteDBPath      string     `env:"GEOLITE_DB_PATH"`
 	GeoLiteDBUrl       string     `env:"GEOLITE_DB_URL"`
@@ -53,6 +54,7 @@ var EnvConfig = &EnvConfigSchema{
 	Port:               "1411",
 	Host:               "0.0.0.0",
 	UnixSocket:         "",
+	UnixSocketMode:     "",
 	MaxMindLicenseKey:  "",
 	GeoLiteDBPath:      "data/GeoLite2-City.mmdb",
 	GeoLiteDBUrl:       MaxMindGeoLiteCityUrl,


### PR DESCRIPTION
This is a supplement to #615.

It is difficult to set socket permissions externally, so add new option to set socket permissions internally.