### PR TITLE
fix: remove duplicate request logging

### DIFF
--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -48,7 +48,6 @@ func initRouterInternal(db *gorm.DB, svc *services) (utils.Service, error) {
 	}
 
 	r := gin.Default()
-	r.Use(gin.Logger())
 
 	if !common.EnvConfig.TrustProxy {
 		_ = r.SetTrustedProxies(nil)


### PR DESCRIPTION
Gin's default engine constructor already adds the logger by default: https://github.com/gin-gonic/gin/blob/v1.10.0/gin.go#L224

---

I noticed requests being logged twice in the logs and found some related issues in the Gin repo. This may be related to #294 where the user noticed excessive logging.

Before:

```
❯ xh http://localhost:1411/healthz
HTTP/1.1 204 No Content
Date: Tue, 24 Jun 2025 07:46:20 GMT

[GIN] 2025/06/24 - 08:46:20 | 204 |         917ns |       127.0.0.1 | GET      "/healthz"
[GIN] 2025/06/24 - 08:46:20 | 204 |      33.791µs |       127.0.0.1 | GET      "/healthz"
```

After:

```
❯ xh http://localhost:1411/healthz
HTTP/1.1 204 No Content
Date: Tue, 24 Jun 2025 07:47:19 GMT

[GIN] 2025/06/24 - 08:47:19 | 204 |      14.958µs |       127.0.0.1 | GET      "/healthz"
```