### PR TITLE
i18n: Fix inconsistent punctuation marks for the language name of zh-TW

### DIFF
--- a/frontend/src/routes/settings/account/locale-picker.svelte
+++ b/frontend/src/routes/settings/account/locale-picker.svelte
@@ -21,7 +21,7 @@
 		'pt-BR': 'Português brasileiro',
 		ru: 'Русский',
 		'zh-CN': '简体中文',
-		'zh-TW': '繁體中文（臺灣)'
+		'zh-TW': '繁體中文（臺灣）'
 	};
 
 	async function updateLocale(locale: Locale) {


### PR DESCRIPTION
# PLEASE, STOP USING MACHINE SUGGESTIONS WITHOUT SUPERVISED

## I have checked https://github.com/pocket-id/pocket-id/issues/628 , I didn't type it wrong!