### PR TITLE
fix: login failures on Postgres when IP is null

### DIFF
--- a/backend/internal/middleware/rate_limit.go
+++ b/backend/internal/middleware/rate_limit.go
@@ -29,7 +29,7 @@ func (m *RateLimitMiddleware) Add(limit rate.Limit, burst int) gin.HandlerFunc {
 
 		// Skip rate limiting for localhost and test environment
 		// If the client ip is localhost the request comes from the frontend
-		if ip == "127.0.0.1" || ip == "::1" || common.EnvConfig.AppEnv == "test" {
+		if ip == "" || ip == "127.0.0.1" || ip == "::1" || common.EnvConfig.AppEnv == "test" {
 			c.Next()
 			return
 		}

--- a/backend/internal/service/user_service.go
+++ b/backend/internal/service/user_service.go
@@ -469,9 +469,7 @@ func (s *UserService) ExchangeOneTimeAccessToken(ctx context.Context, token stri
 		return model.User{}, "", err
 	}
 
-	if ipAddress != "" && userAgent != "" {
-		s.auditLogService.Create(ctx, model.AuditLogEventOneTimeAccessTokenSignIn, ipAddress, userAgent, oneTimeAccessToken.User.ID, model.AuditLogData{}, tx)
-	}
+	s.auditLogService.Create(ctx, model.AuditLogEventOneTimeAccessTokenSignIn, ipAddress, userAgent, oneTimeAccessToken.User.ID, model.AuditLogData{}, tx)
 
 	err = tx.Commit().Error
 	if err != nil {


### PR DESCRIPTION
fixes #686 (for real)

The fix in #695 was not complete. It allowed the entry to be stored in the DB, but still caused failures when reading. This completes the fix.

Also fixes: authenticating with a one-time code did not create a log entry when the IP is empty