### PR TITLE
feat: add robots.txt to block indexing

### DIFF
--- a/frontend/static/robots.txt
+++ b/frontend/static/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /
+Noindex: /


### PR DESCRIPTION
Linked to #766

Serve a robots.txt which forbids both exploring and indexing by crawlers of all user agent
Hopefully this should stop indexing.

Note : If any other user gets their site indexed they can edit search results and delete them via the google search console if they own the domain under which their instance is served.