### PR TITLE
chore: additional logs for database connections

### DIFF
--- a/backend/internal/bootstrap/db_bootstrap.go
+++ b/backend/internal/bootstrap/db_bootstrap.go
@@ -110,12 +110,15 @@ func connectDatabase() (db *gorm.DB, err error) {
 			Logger:         getGormLogger(),
 		})
 		if err == nil {
+			slog.Info("Connected to database", slog.String("provider", string(common.EnvConfig.DbProvider)))
 			return db, nil
 		}
 
-		slog.Info("Failed to initialize database", slog.Int("attempt", i))
+		slog.Warn("Failed to connect to database, will retry in 3s", slog.Int("attempt", i), slog.String("provider", string(common.EnvConfig.DbProvider)), slog.Any("error", err))
 		time.Sleep(3 * time.Second)
 	}
+
+	slog.Error("Failed to connect to database after 3 attempts", slog.String("provider", string(common.EnvConfig.DbProvider)), slog.Any("error", err))
 
 	return nil, err
 }


### PR DESCRIPTION
Adding some additional log statements to the code creating database connections, to have some more debugging info.

This morning, I noticed that the pocket-id container in my server was not responding because something was wrong with the database (it probably wasn't up yet). Despite that, Pocket ID still started a server.

Logs here were not enough to understand what happened (they show a DNS resolution error, but it then didn't retry):

```
Aug 06 00:20:33 apps pocketid-pocketid[499293]: 2025/08/06 00:20:33 Server listening on 0.0.0.0:1411
Aug 06 00:20:33 apps pocketid-pocketid[499293]: 2025/08/06 00:20:33 INFO Starting job scheduler
Aug 06 00:20:33 apps pocketid-pocketid[499293]: 2025/08/06 00:20:33 INFO Starting job name=ClearAuditLogs id=a3df48ee-b481-4572-9fc1-4e81030891d5
Aug 06 00:20:33 apps pocketid-pocketid[499293]: 2025/08/06 00:20:33 INFO Starting job name=ClearOidcRefreshTokens id=90ad5821-0936-48f6-8558-604941eb8e9d
Aug 06 00:20:33 apps pocketid-pocketid[499293]: 2025/08/06 00:20:33 INFO Starting job name=ClearOneTimeAccessTokens id=1d632227-fe24-4bee-80bf-80f71c92ae7e
Aug 06 00:20:33 apps pocketid-pocketid[499293]: 2025/08/06 00:20:33 INFO Starting job name=SyncLdap id=f43a66c3-fdb7-4374-8c45-f56c3d2c82d0
Aug 06 00:20:33 apps pocketid-pocketid[499293]: 2025/08/06 00:20:33 INFO Job run successfully name=SyncLdap id=f43a66c3-fdb7-4374-8c45-f56c3d2c82d0
Aug 06 00:20:33 apps pocketid-pocketid[499293]: 2025/08/06 00:20:33 INFO Starting job name=ClearSignupTokens id=977effbf-ebbb-4bb9-b2b3-118229b38b99
Aug 06 00:20:33 apps pocketid-pocketid[499293]: 2025/08/06 00:20:33 INFO Starting job name=ClearOidcAuthorizationCodes id=a12ffd3c-5586-44a3-8fbf-d66786fbb39c
lines 1196-1229/1353 86%
Aug 06 00:20:30 apps pocketid-pocketid[499293]:
Aug 06 00:20:30 apps pocketid-pocketid[499293]: 2025/08/06 00:20:30 github.com/pocket-id/pocket-id/backend/internal/bootstrap/db_bootstrap.go:108
Aug 06 00:20:30 apps pocketid-pocketid[499293]: [error] failed to initialize database, got error failed to connect to `user=pocketid database=pocketid`:
Aug 06 00:20:30 apps pocketid-pocketid[499293]:         hostname resolving error: lookup postgres on 172.16.0.1:53: no such host
Aug 06 00:20:30 apps pocketid-pocketid[499293]:         lookup postgres on 172.16.0.1:53: no such host
Aug 06 00:20:30 apps pocketid-pocketid[499293]: 2025/08/06 00:20:30 Attempt 1: Failed to initialize database. Retrying...
Aug 06 00:20:33 apps pocketid-pocketid[499293]: 2025/08/06 00:20:33 Server listening on 0.0.0.0:1411
```

These new logs should help troubleshoot if the issue happens in the future, hopefully.