### PR TITLE
fix: ignore client secret if client is public

### DIFF
--- a/backend/internal/service/oidc_service.go
+++ b/backend/internal/service/oidc_service.go
@@ -1462,8 +1462,8 @@ func (s *OidcService) verifyClientCredentialsInternal(ctx context.Context, tx *g
 
 	// Validate credentials based on the authentication method
 	switch {
-	// First, if we have a client secret, we validate it
-	case input.ClientSecret != "":
+	// First, if we have a client secret, we validate it unless client is marked as public
+	case input.ClientSecret != "" && !client.IsPublic:
 		err = bcrypt.CompareHashAndPassword([]byte(client.Secret), []byte(input.ClientSecret))
 		if err != nil {
 			return nil, &common.OidcClientSecretInvalidError{}


### PR DESCRIPTION
feat to allow a user to specify a (Confidential + PKCE)  Client as a Public Client instead.

This is necessary for clients setup as confidential + PKCE authorization that do not protect client secrets properly.

One example is ownCloud OCIS ( Desktop/Android/IOS ) - the client secret is expected to be a hard coded/public value - see https://doc.owncloud.com/server/next/admin_manual/configuration/user/oidc/oidc.html#client-ids-secrets-and-redirect-uris)

This is incorrect implementation by the service, however PocketID should ignore any client secret attached to a request for access from a Public Client as the spec does not expect this. This will allow support for these services as Public clients for now (once custom Client ID support is implemented).
