### PR TITLE
fix: move audit log call before TX is committed

### DIFF
--- a/backend/internal/service/webauthn_service.go
+++ b/backend/internal/service/webauthn_service.go
@@ -263,12 +263,12 @@ func (s *WebAuthnService) VerifyLogin(ctx context.Context, sessionID string, cre
 		return model.User{}, "", err
 	}
 
+	s.auditLogService.CreateNewSignInWithEmail(ctx, ipAddress, userAgent, user.ID, tx)
+
 	err = tx.Commit().Error
 	if err != nil {
 		return model.User{}, "", err
 	}
-
-	s.auditLogService.CreateNewSignInWithEmail(ctx, ipAddress, userAgent, user.ID, tx)
 
 	return *user, token, nil
 }


### PR DESCRIPTION
Partially reverts fe003b927ce7772692439992860c804de89ce424 . Calls to `CreateNewSignInWithEmail` accept a transaction, so they should be made before the tx is committed