### PR TITLE
fix: wrong column type for reauthentication tokens in Postgres

### DIFF
--- a/backend/resources/migrations/postgres/20250814121300_requires_reauthentication.up.sql
+++ b/backend/resources/migrations/postgres/20250814121300_requires_reauthentication.up.sql
@@ -5,7 +5,7 @@ CREATE TABLE reauthentication_tokens (
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     token TEXT NOT NULL UNIQUE,
     expires_at TIMESTAMPTZ NOT NULL,
-    user_id TEXT NOT NULL REFERENCES users ON DELETE CASCADE
+    user_id uuid NOT NULL REFERENCES users ON DELETE CASCADE
 );
 
 CREATE INDEX idx_reauthentication_tokens_token ON reauthentication_tokens(token);


### PR DESCRIPTION
fixes #866

The column type for Postgres should be UUID