### PR TITLE
fix: update localized name and description of ldap group name attribute

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -215,7 +215,7 @@
 	"group_members_attribute": "Group Members Attribute",
 	"the_attribute_to_use_for_querying_members_of_a_group": "The attribute to use for querying members of a group.",
 	"group_unique_identifier_attribute": "Group Unique Identifier Attribute",
-	"group_name_attribute": "Group Name Attribute",
+	"group_rdn_attribute": "Group RDN Attribute (in DN)",
 	"admin_group_name": "Admin Group Name",
 	"members_of_this_group_will_have_admin_privileges_in_pocketid": "Members of this group will have Admin Privileges in Pocket ID.",
 	"disable": "Disable",
@@ -442,6 +442,6 @@
 	"invalid_client_id": "Client ID can only contain letters, numbers, underscores, and hyphens",
 	"custom_client_id_description": "Set a custom client ID if this is required by your application. Otherwise, leave it blank to generate a random one.",
 	"generated": "Generated",
-  "administration": "Administration"
-
+	"administration": "Administration",
+	"group_rdn_attribute_description": "The attribute used in the groups distinguished name (DN). Recommended value: `cn`"
 }

--- a/frontend/src/routes/settings/admin/application-configuration/forms/app-config-ldap-form.svelte
+++ b/frontend/src/routes/settings/admin/application-configuration/forms/app-config-ldap-form.svelte
@@ -200,7 +200,8 @@
 				bind:input={$inputs.ldapAttributeGroupUniqueIdentifier}
 			/>
 			<FormInput
-				label={m.group_name_attribute()}
+				label={m.group_rdn_attribute()}
+				description={m.group_rdn_attribute_description()}
 				placeholder="cn"
 				bind:input={$inputs.ldapAttributeGroupName}
 			/>


### PR DESCRIPTION
Fixes: https://github.com/pocket-id/pocket-id/issues/838

This is a simple update to the localizations for the ldap Group Name Atribute, Update the descriptions to be more proper is what it actually is to hopefully alleviate some confusion, in the next breaking release we should rename the actual variable as well from `ldapAttributeGroupName > ldapAttributeGroupRDN`