### PR TITLE
fix: ensure users imported from LDAP have fields validated

### DIFF
--- a/backend/internal/dto/user_dto.go
+++ b/backend/internal/dto/user_dto.go
@@ -1,6 +1,9 @@
 package dto
 
 import (
+	"errors"
+
+	"github.com/gin-gonic/gin/binding"
 	"github.com/pocket-id/pocket-id/backend/internal/utils"
 )
 
@@ -27,6 +30,17 @@ type UserCreateDto struct {
 	Locale    *string `json:"locale"`
 	Disabled  bool    `json:"disabled"`
 	LdapID    string  `json:"-"`
+}
+
+func (u UserCreateDto) Validate() error {
+	e, ok := binding.Validator.Engine().(interface {
+		Struct(s any) error
+	})
+	if !ok {
+		return errors.New("validator does not implement the expected interface")
+	}
+
+	return e.Struct(u)
 }
 
 type OneTimeAccessTokenCreateDto struct {

--- a/backend/internal/dto/user_dto_test.go
+++ b/backend/internal/dto/user_dto_test.go
@@ -1,0 +1,89 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserCreateDto_Validate(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   UserCreateDto
+		wantErr string
+	}{
+		{
+			name: "valid input",
+			input: UserCreateDto{
+				Username:  "testuser",
+				Email:     "test@example.com",
+				FirstName: "John",
+				LastName:  "Doe",
+			},
+			wantErr: "",
+		},
+		{
+			name: "missing username",
+			input: UserCreateDto{
+				Email:     "test@example.com",
+				FirstName: "John",
+				LastName:  "Doe",
+			},
+			wantErr: "Field validation for 'Username' failed on the 'required' tag",
+		},
+		{
+			name: "username contains invalid characters",
+			input: UserCreateDto{
+				Username:  "test/ser",
+				Email:     "test@example.com",
+				FirstName: "John",
+				LastName:  "Doe",
+			},
+			wantErr: "Field validation for 'Username' failed on the 'username' tag",
+		},
+		{
+			name: "invalid email",
+			input: UserCreateDto{
+				Username:  "testuser",
+				Email:     "not-an-email",
+				FirstName: "John",
+				LastName:  "Doe",
+			},
+			wantErr: "Field validation for 'Email' failed on the 'email' tag",
+		},
+		{
+			name: "first name too short",
+			input: UserCreateDto{
+				Username:  "testuser",
+				Email:     "test@example.com",
+				FirstName: "",
+				LastName:  "Doe",
+			},
+			wantErr: "Field validation for 'FirstName' failed on the 'required' tag",
+		},
+		{
+			name: "last name too long",
+			input: UserCreateDto{
+				Username:  "testuser",
+				Email:     "test@example.com",
+				FirstName: "John",
+				LastName:  "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
+			},
+			wantErr: "Field validation for 'LastName' failed on the 'max' tag",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.input.Validate()
+
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}

--- a/backend/internal/dto/validations.go
+++ b/backend/internal/dto/validations.go
@@ -10,29 +10,29 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
+// [a-zA-Z0-9]      : The username must start with an alphanumeric character
+// [a-zA-Z0-9_.@-]* : The rest of the username can contain alphanumeric characters, dots, underscores, hyphens, and "@" symbols
+// [a-zA-Z0-9]$     : The username must end with an alphanumeric character
+var validateUsernameRegex = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.@-]*[a-zA-Z0-9]$")
+
+var validateClientIDRegex = regexp.MustCompile("^[a-zA-Z0-9._-]+$")
+
 func init() {
 	v := binding.Validator.Engine().(*validator.Validate)
-
-	// [a-zA-Z0-9]      : The username must start with an alphanumeric character
-	// [a-zA-Z0-9_.@-]* : The rest of the username can contain alphanumeric characters, dots, underscores, hyphens, and "@" symbols
-	// [a-zA-Z0-9]$     : The username must end with an alphanumeric character
-	var validateUsernameRegex = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.@-]*[a-zA-Z0-9]$")
-
-	var validateClientIDRegex = regexp.MustCompile("^[a-zA-Z0-9._-]+$")
 
 	// Maximum allowed value for TTLs
 	const maxTTL = 31 * 24 * time.Hour
 
 	// Errors here are development-time ones
 	err := v.RegisterValidation("username", func(fl validator.FieldLevel) bool {
-		return validateUsernameRegex.MatchString(fl.Field().String())
+		return ValidateUsername(fl.Field().String())
 	})
 	if err != nil {
 		panic("Failed to register custom validation for username: " + err.Error())
 	}
 
 	err = v.RegisterValidation("client_id", func(fl validator.FieldLevel) bool {
-		return validateClientIDRegex.MatchString(fl.Field().String())
+		return ValidateClientID(fl.Field().String())
 	})
 	if err != nil {
 		panic("Failed to register custom validation for client_id: " + err.Error())
@@ -49,4 +49,14 @@ func init() {
 	if err != nil {
 		panic("Failed to register custom validation for ttl: " + err.Error())
 	}
+}
+
+// ValidateUsername validates username inputs
+func ValidateUsername(username string) bool {
+	return validateUsernameRegex.MatchString(username)
+}
+
+// ValidateClientID validates client ID inputs
+func ValidateClientID(clientID string) bool {
+	return validateClientIDRegex.MatchString(clientID)
 }


### PR DESCRIPTION
Fixes a side issue discovered in #909, where users imported from LDAP did not go through validation rules.

Note: after upgrading, if the database contains LDAP-imported users that fail the validation, those will not be updated anymore and users should see warnings in the logs.