### PR TITLE
fix: remove previous socket file to prevent bind error

### DIFF
--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -119,6 +119,7 @@ func initRouterInternal(db *gorm.DB, svc *services) (utils.Service, error) {
 	if common.EnvConfig.UnixSocket != "" {
 		network = "unix"
 		addr = common.EnvConfig.UnixSocket
+		os.Remove(addr) // remove dangling the socket file to avoid file-exist error
 	}
 
 	listener, err := net.Listen(network, addr) //nolint:noctx


### PR DESCRIPTION
Unix sockets cannot be created if the file already exists. The current socket file can be left behind if pocket-id closes ungracefully, either because of a crash or if the system loses power.

In those cases pocket-id fails to restart with the following error:

> failed to init router: failed to create unix listener: listen unix /pocketid/pocketid.sock: bind: address already in use

This PR removes the previous socket file, if it exists, before creating the router.