### PR TITLE
feat: add profile photos to user list table

### DIFF
--- a/frontend/src/routes/settings/admin/users/user-list.svelte
+++ b/frontend/src/routes/settings/admin/users/user-list.svelte
@@ -23,6 +23,8 @@
 	} from '@lucide/svelte';
 	import Ellipsis from '@lucide/svelte/icons/ellipsis';
 	import { toast } from 'svelte-sonner';
+	import { cachedProfilePicture } from '$lib/utils/cached-image-util';
+	import * as Avatar from '$lib/components/ui/avatar';
 
 	let {
 		users = $bindable(),
@@ -101,6 +103,7 @@
 	{requestOptions}
 	onRefresh={async (options) => (users = await userService.list(options))}
 	columns={[
+		{ label: m.profile_picture()},
 		{ label: m.first_name(), sortColumn: 'firstName' },
 		{ label: m.last_name(), sortColumn: 'lastName' },
 		{ label: m.display_name(), sortColumn: 'displayName' },
@@ -113,6 +116,11 @@
 	]}
 >
 	{#snippet rows({ item })}
+		<Table.Cell>
+			<Avatar.Root class="size-10">
+				<Avatar.Image class="object-cover" src={cachedProfilePicture.getUrl(item.id)} />
+			</Avatar.Root>
+		</Table.Cell>
 		<Table.Cell>{item.firstName}</Table.Cell>
 		<Table.Cell>{item.lastName}</Table.Cell>
 		<Table.Cell>{item.displayName}</Table.Cell>


### PR DESCRIPTION
This PR adds the profile picture to the admin user management page.

<img width="1121" height="430" alt="image" src="https://github.com/user-attachments/assets/355c42da-f78d-4357-9351-b00e0f6191fc" />


Closes #947