### PR TITLE
fix: use credProps to save passkey on firefox android

### DIFF
--- a/backend/internal/service/webauthn_service.go
+++ b/backend/internal/service/webauthn_service.go
@@ -81,6 +81,7 @@ func (s *WebAuthnService) BeginRegistration(ctx context.Context, userID string) 
 		&user,
 		webauthn.WithResidentKeyRequirement(protocol.ResidentKeyRequirementRequired),
 		webauthn.WithExclusions(user.WebAuthnCredentialDescriptors()),
+		webauthn.WithExtensions(map[string]any{"credProps": true}), // Required for Firefox Android to properly save the key in Google password manager
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to begin WebAuthn registration: %w", err)


### PR DESCRIPTION
Fixes https://github.com/pocket-id/pocket-id/issues/403

Main issue:

When creating a new passkey from firefox android (same with firefox nightly) the key isn't actually saved in Google password manager. No error is displayed, public key is created in pocket id, but private key is lost. note: this happens without any extension installed (no bitwarden or similar can intervene).

Investigation:

As mentioned in the comments from the issue, the https://webauthn.io/ demo can save the passkey from firefox android. I started to compare the options returned for the passkey registration and saw one main difference between the two: `credProps: true` in the `extensions` object.

This suspicion was confirmed using https://www.webauthn.me/debugger where by default passkeys weren't saved using firefox android like on pocket-id, but was fixed by enabling the `credProps` extension.

This adds the relevant code to enable this extension and takes inspiration (or rather copy paste) from go-webauthn passkey example code:
https://github.com/go-webauthn/webauthn/blob/a664f002fd15d5b7393a19bb325a58df2633326b/webauthn/example_passkey_test.go#L98

(built pocket-id locally and confirmed the fix)