### PR TITLE
fix: dark oidc client icons not saved on client creation

### DIFF
--- a/frontend/src/routes/authorize/components/client-provider-images.svelte
+++ b/frontend/src/routes/authorize/components/client-provider-images.svelte
@@ -6,6 +6,7 @@
 	import { m } from '$lib/paraglide/messages';
 	import type { OidcClientMetaData } from '$lib/types/oidc.type';
 	import { cachedOidcClientLogo } from '$lib/utils/cached-image-util';
+	import { mode } from 'mode-watcher';
 
 	const {
 		success,
@@ -28,6 +29,8 @@
 			animationDone = false;
 		}
 	});
+
+	const isLightMode = $derived(mode.current === 'light');
 </script>
 
 <div class="flex justify-center gap-3">
@@ -60,8 +63,8 @@
 			</div>
 		{:else if client.hasLogo}
 			<img
-				class="size-10 aspect-square object-contain"
-				src={cachedOidcClientLogo.getUrl(client.id)}
+				class="aspect-square size-10 object-contain"
+				src={cachedOidcClientLogo.getUrl(client.id, isLightMode)}
 				draggable={false}
 				alt={m.client_logo()}
 			/>

--- a/frontend/src/routes/settings/admin/oidc-clients/+page.svelte
+++ b/frontend/src/routes/settings/admin/oidc-clients/+page.svelte
@@ -21,9 +21,15 @@
 	async function createOIDCClient(client: OidcClientCreateWithLogo) {
 		try {
 			const createdClient = await oidcService.createClient(client);
-			if (client.logo) {
-				await oidcService.updateClientLogo(createdClient, client.logo);
-			}
+
+			const logoPromise = client.logo
+				? oidcService.updateClientLogo(createdClient, client.logo, true)
+				: Promise.resolve();
+			const darkLogoPromise = client.darkLogo
+				? oidcService.updateClientLogo(createdClient, client.darkLogo, false)
+				: Promise.resolve();
+			await Promise.all([logoPromise, darkLogoPromise]);
+
 			const clientSecret = await oidcService.createClientSecret(createdClient.id);
 			clientSecretStore.set(clientSecret);
 			goto(`/settings/admin/oidc-clients/${createdClient.id}`);

--- a/frontend/src/routes/settings/admin/users/+page.svelte
+++ b/frontend/src/routes/settings/admin/users/+page.svelte
@@ -113,5 +113,5 @@
 	</Card.Root>
 </div>
 
-<SignupTokenModal bind:open={signupTokenModalOpen}  />
+<SignupTokenModal bind:open={signupTokenModalOpen} />
 <SignupTokenListModal bind:open={signupTokenListModalOpen} />


### PR DESCRIPTION
- Create didn't pass the dark logo to the backend.
- Authorization page didn't use dark mode icons.