### PR TITLE
chore: update example .env to use database for keys storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,11 @@ TRUST_PROXY=false
 MAXMIND_LICENSE_KEY=
 PUID=1000
 PGID=1000
+KEYS_STORAGE=database
+
+# Encryption key used to protect sensitive data
+# Can be generated with `openssl rand -base64 32`
+# See https://pocket-id.org/docs/configuration/environment-variables#encryption-keys
+ENCRYPTION_KEY=
+# Alternatively, point to a file containing the key (could be a Docker secret)
+#ENCRYPTION_KEY_FILE=

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ Thumbs.db
 .env.*
 !.env.development-example
 !.env.test
+!.env.example
 
 # Vite
 vite.config.js.timestamp-*


### PR DESCRIPTION
Given recent conversations on how the database will be the preferred (or sole) method in a future release, start by updating the example env