### PR TITLE
fix!: rename `LDAP_ATTRIBUTE_ADMIN_GROUP` env variable to `LDAP_ADMIN_GROUP_NAME`

### DIFF
--- a/backend/internal/dto/app_config_dto.go
+++ b/backend/internal/dto/app_config_dto.go
@@ -47,7 +47,7 @@ type AppConfigUpdateDto struct {
 	LdapAttributeGroupMember                   string `json:"ldapAttributeGroupMember"`
 	LdapAttributeGroupUniqueIdentifier         string `json:"ldapAttributeGroupUniqueIdentifier"`
 	LdapAttributeGroupName                     string `json:"ldapAttributeGroupName"`
-	LdapAttributeAdminGroup                    string `json:"ldapAttributeAdminGroup"`
+	LdapAdminGroupName                         string `json:"ldapAdminGroupName"`
 	LdapSoftDeleteUsers                        string `json:"ldapSoftDeleteUsers"`
 	EmailOneTimeAccessAsAdminEnabled           string `json:"emailOneTimeAccessAsAdminEnabled" binding:"required"`
 	EmailOneTimeAccessAsUnauthenticatedEnabled string `json:"emailOneTimeAccessAsUnauthenticatedEnabled" binding:"required"`

--- a/backend/internal/model/app_config.go
+++ b/backend/internal/model/app_config.go
@@ -77,7 +77,7 @@ type AppConfig struct {
 	LdapAttributeGroupMember           AppConfigVariable `key:"ldapAttributeGroupMember"`
 	LdapAttributeGroupUniqueIdentifier AppConfigVariable `key:"ldapAttributeGroupUniqueIdentifier"`
 	LdapAttributeGroupName             AppConfigVariable `key:"ldapAttributeGroupName"`
-	LdapAttributeAdminGroup            AppConfigVariable `key:"ldapAttributeAdminGroup"`
+	LdapAdminGroupName                 AppConfigVariable `key:"ldapAdminGroupName"`
 	LdapSoftDeleteUsers                AppConfigVariable `key:"ldapSoftDeleteUsers"`
 }
 

--- a/backend/internal/service/app_config_service.go
+++ b/backend/internal/service/app_config_service.go
@@ -102,7 +102,7 @@ func (s *AppConfigService) getDefaultDbConfig() *model.AppConfig {
 		LdapAttributeGroupMember:           model.AppConfigVariable{Value: "member"},
 		LdapAttributeGroupUniqueIdentifier: model.AppConfigVariable{},
 		LdapAttributeGroupName:             model.AppConfigVariable{},
-		LdapAttributeAdminGroup:            model.AppConfigVariable{},
+		LdapAdminGroupName:                 model.AppConfigVariable{},
 		LdapSoftDeleteUsers:                model.AppConfigVariable{Value: "true"},
 	}
 }

--- a/backend/internal/service/e2etest_service.go
+++ b/backend/internal/service/e2etest_service.go
@@ -529,7 +529,7 @@ func (s *TestService) SetLdapTestConfig(ctx context.Context) error {
 			"ldapAttributeGroupUniqueIdentifier": "uuid",
 			"ldapAttributeGroupName":             "uid",
 			"ldapAttributeGroupMember":           "member",
-			"ldapAttributeAdminGroup":            "admin_group",
+			"ldapAdminGroupName":                 "admin_group",
 			"ldapSoftDeleteUsers":                "true",
 			"ldapEnabled":                        "true",
 		}

--- a/backend/internal/service/ldap_service.go
+++ b/backend/internal/service/ldap_service.go
@@ -341,7 +341,7 @@ func (s *LdapService) SyncUsers(ctx context.Context, tx *gorm.DB, client *ldap.C
 		// Check if user is admin by checking if they are in the admin group
 		isAdmin := false
 		for _, group := range value.GetAttributeValues("memberOf") {
-			if getDNProperty(dbConfig.LdapAttributeGroupName.Value, group) == dbConfig.LdapAttributeAdminGroup.Value {
+			if getDNProperty(dbConfig.LdapAttributeGroupName.Value, group) == dbConfig.LdapAdminGroupName.Value {
 				isAdmin = true
 				break
 			}

--- a/frontend/src/lib/types/application-configuration.ts
+++ b/frontend/src/lib/types/application-configuration.ts
@@ -47,7 +47,7 @@ export type AllAppConfig = AppConfig & {
 	ldapAttributeGroupMember: string;
 	ldapAttributeGroupUniqueIdentifier: string;
 	ldapAttributeGroupName: string;
-	ldapAttributeAdminGroup: string;
+	ldapAdminGroupName: string;
 	ldapSoftDeleteUsers: boolean;
 };
 

--- a/frontend/src/routes/settings/admin/application-configuration/forms/app-config-ldap-form.svelte
+++ b/frontend/src/routes/settings/admin/application-configuration/forms/app-config-ldap-form.svelte
@@ -43,7 +43,7 @@
 		ldapAttributeGroupMember: z.string().optional(),
 		ldapAttributeGroupUniqueIdentifier: z.string().min(1),
 		ldapAttributeGroupName: z.string().min(1),
-		ldapAttributeAdminGroup: z.string().optional(),
+		ldapAdminGroupName: z.string().optional(),
 		ldapSoftDeleteUsers: z.boolean()
 	});
 
@@ -193,7 +193,7 @@
 				label={m.admin_group_name()}
 				description={m.members_of_this_group_will_have_admin_privileges_in_pocketid()}
 				placeholder="_admin_group_name"
-				bind:input={$inputs.ldapAttributeAdminGroup}
+				bind:input={$inputs.ldapAdminGroupName}
 			/>
 		</div>
 	</fieldset>


### PR DESCRIPTION
Fixes #619.

Breaking changes:
- `LDAP_ATTRIBUTE_ADMIN_GROUP` renamed to `LDAP_ADMIN_GROUP_NAME`.