### PR TITLE
fix/doc: Update launch.json and Contributing doc with minor fixes for first time setup of dev environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,6 @@ The backend is built with [Gin](https://gin-gonic.com) and written in Go. To set
 2. Copy the `.env.development-example` file to `.env` and edit the variables as needed
 3. Start the backend with `go run -tags exclude_frontend ./cmd`
 
-* Note: May need to create `data` folder in `backend` folder
-
 ### Frontend
 
 The frontend is built with [SvelteKit](https://kit.svelte.dev) and written in TypeScript. To set it up, follow these steps:


### PR DESCRIPTION
When getting setup for the first time to try and implement #742 there were a couple of minor things I had to adjust to get up and running.

fix: Set correct path of .env file to backend dir instead of backend/cmd
fix: Set tag=exclude_frontend when working with backend in debug mode to match go run
fix: Set working directory to backend/ when working in backend mode in debug mode instead of backend/cmd to match go run
doc: Added note that may need to create a `data` directory in backend/ so that the sqlite database will be created