### PR TITLE
feat: add issuer url to oidc client url list

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -498,5 +498,6 @@
 	"scim_sync_successful": "The SCIM sync has been completed successfully.",
 	"save_and_sync": "Save and Sync",
 	"scim_save_changes_description": "You have to save the changes before starting a SCIM sync. Do you want to save now?",
-	"scopes": "Scopes"
+	"scopes": "Scopes",
+	"issuer_url": "Issuer URL"
 }

--- a/frontend/src/routes/settings/admin/oidc-clients/[id]/+page.svelte
+++ b/frontend/src/routes/settings/admin/oidc-clients/[id]/+page.svelte
@@ -38,6 +38,7 @@
 	const backNavigation = backNavigate('/settings/admin/oidc-clients');
 
 	const setupDetails = $state({
+		[m.issuer_url()]: `https://${page.url.host}`,
 		[m.authorization_url()]: `https://${page.url.host}/authorize`,
 		[m.oidc_discovery_url()]: `https://${page.url.host}/.well-known/openid-configuration`,
 		[m.token_url()]: `https://${page.url.host}/api/oidc/token`,
@@ -207,14 +208,14 @@
 	<Card.Content>
 		<div class="flex flex-col">
 			<div class="mb-2 flex flex-col sm:flex-row sm:items-center">
-				<Field.Label class="w-50">{m.client_id()}</Field.Label>
+				<Field.Label class="w-52">{m.client_id()}</Field.Label>
 				<CopyToClipboard value={client.id}>
 					<span class="text-muted-foreground text-sm" data-testid="client-id"> {client.id}</span>
 				</CopyToClipboard>
 			</div>
 			{#if !client.isPublic}
 				<div class="mt-1 mb-2 flex flex-col sm:flex-row sm:items-center">
-					<Field.Label class="w-50">{m.client_secret()}</Field.Label>
+					<Field.Label class="w-52">{m.client_secret()}</Field.Label>
 					{#if $clientSecretStore}
 						<CopyToClipboard value={$clientSecretStore}>
 							<span class="text-muted-foreground text-sm" data-testid="client-secret">
@@ -240,8 +241,8 @@
 			{#if showAllDetails}
 				<div transition:slide>
 					{#each Object.entries(setupDetails) as [key, value]}
-						<div class="mb-5 flex flex-col sm:flex-row sm:items-center">
-							<Field.Label class="w-50">{key}</Field.Label>
+						<div class="mb-2 flex flex-col sm:flex-row sm:items-center">
+							<Field.Label class="w-52">{key}</Field.Label>
 							<CopyToClipboard {value}>
 								<span class="text-muted-foreground text-sm">{value}</span>
 							</CopyToClipboard>


### PR DESCRIPTION
Simple enhancement that adds the issuer url to the list of the OIDC client urls. Some clients make sue of the issuer url to then auto discover the other urls based off the discovery endpoint: https://github.com/pocket-id/pocket-id/discussions/611