### PR TITLE
feat: add VERSION_CHECK_DISABLED environment variable

### DIFF
--- a/backend/internal/common/env_config.go
+++ b/backend/internal/common/env_config.go
@@ -50,6 +50,7 @@ type EnvConfigSchema struct {
 	InternalAppURL        string `env:"INTERNAL_APP_URL"`
 	UiConfigDisabled      bool   `env:"UI_CONFIG_DISABLED"`
 	DisableRateLimiting   bool   `env:"DISABLE_RATE_LIMITING"`
+	VersionCheckDisabled  bool   `env:"VERSION_CHECK_DISABLED"`
 	StaticApiKey          string `env:"STATIC_API_KEY" options:"file"`
 
 	FileBackend                     string `env:"FILE_BACKEND" options:"toLower"`

--- a/backend/internal/service/version_service.go
+++ b/backend/internal/service/version_service.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pocket-id/pocket-id/backend/internal/common"
 	"github.com/pocket-id/pocket-id/backend/internal/utils"
 )
 
@@ -31,6 +32,10 @@ func NewVersionService(httpClient *http.Client) *VersionService {
 }
 
 func (s *VersionService) GetLatestVersion(ctx context.Context) (string, error) {
+	if common.EnvConfig.VersionCheckDisabled {
+		return "", nil
+	}
+
 	version, err := s.cache.GetOrFetch(ctx, func(ctx context.Context) (string, error) {
 		reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()

--- a/frontend/src/routes/settings/+layout.ts
+++ b/frontend/src/routes/settings/+layout.ts
@@ -10,8 +10,13 @@ export const load: LayoutLoad = async () => {
 	let isUpToDate = true;
 	try {
 		newestVersion = await versionService.getNewestVersion();
-		isUpToDate = newestVersion === currentVersion;
-	} catch {}
+		// If newestVersion is empty, it means the check is disabled or failed.
+		// In this case, we assume the version is up to date.
+		isUpToDate = newestVersion === '' || newestVersion === currentVersion;
+	} catch {
+		// If the request fails, assume up-to-date to avoid showing a warning.
+		isUpToDate = true;
+	}
 
 	const versionInformation: AppVersionInformation = {
 		currentVersion: versionService.getCurrentVersion(),


### PR DESCRIPTION
Allows disabling the automatic version check in the backend. This is useful for air-gapped environments where external requests to the version endpoint fail or time out. The frontend has been updated to handle disabled checks gracefully.

Doc changes under: https://github.com/pocket-id/website/pull/208