### PR TITLE
fix: prevent deletion of OIDC provider logo for non admin/anonymous users

### DIFF
--- a/backend/internal/controller/oidc_controller.go
+++ b/backend/internal/controller/oidc_controller.go
@@ -47,7 +47,7 @@ func NewOidcController(group *gin.RouterGroup, authMiddleware *middleware.AuthMi
 	group.POST("/oidc/clients/:id/secret", authMiddleware.Add(), oc.createClientSecretHandler)
 
 	group.GET("/oidc/clients/:id/logo", oc.getClientLogoHandler)
-	group.DELETE("/oidc/clients/:id/logo", oc.deleteClientLogoHandler)
+	group.DELETE("/oidc/clients/:id/logo", authMiddleware.Add(), oc.deleteClientLogoHandler)
 	group.POST("/oidc/clients/:id/logo", authMiddleware.Add(), fileSizeLimitMiddleware.Add(2<<20), oc.updateClientLogoHandler)
 
 	group.GET("/oidc/clients/:id/preview/:userId", authMiddleware.Add(), oc.getClientPreviewHandler)


### PR DESCRIPTION
Hello there!

As per #1259 it is currently possible to delete the logo of any OIDC provider, without needing to be logged in. In reality, this action should require `admin` priviliges.

Since I am very new to this project, please let me know in case I am missing some aspect of this report. Happy to work on this :wave: 