### PR TITLE
fix(callback): accept documented wildcard callback patterns

### DIFF
--- a/backend/internal/utils/callback_url_util.go
+++ b/backend/internal/utils/callback_url_util.go
@@ -19,9 +19,15 @@ func ValidateCallbackURLPattern(pattern string) error {
 	}
 
 	pattern, _, _ = strings.Cut(pattern, "#")
-	pattern = normalizeToURLPatternStandard(pattern)
 
-	_, err := urlpattern.New(pattern, "", nil)
+	// go-urlpattern supports wildcard matching during Test(), but validating raw
+	// wildcard host/port patterns directly can reject legitimate callback patterns
+	// such as https://*.example.com/... and https://app.example.com:*/....
+	// For syntax validation, replace wildcard tokens with concrete placeholders.
+	validationPattern := strings.ReplaceAll(pattern, "*", "x")
+	validationPattern = normalizeToURLPatternStandard(validationPattern)
+
+	_, err := urlpattern.New(validationPattern, "", nil)
 	return err
 }
 

--- a/backend/internal/utils/callback_url_util_test.go
+++ b/backend/internal/utils/callback_url_util_test.go
@@ -24,8 +24,18 @@ func TestValidateCallbackURLPattern(t *testing.T) {
 			shouldError: false,
 		},
 		{
+			name:        "wildcard subdomain",
+			pattern:     "https://*.example.com/oauth/callback",
+			shouldError: false,
+		},
+		{
 			name:        "wildcard port",
 			pattern:     "https://example.com:*/callback",
+			shouldError: false,
+		},
+		{
+			name:        "wildcard port with fixed host",
+			pattern:     "https://app.example.com:*/oauth/callback",
 			shouldError: false,
 		},
 		{


### PR DESCRIPTION
## Summary
- fix callback URL validation to accept documented wildcard host/port patterns by validating a wildcard-substituted form (`*` -> `x`) for parser syntax checks
- keep runtime matching behavior unchanged; this only affects pattern acceptance on save
- add regression coverage for `https://*.example.com/oauth/callback` and `https://app.example.com:*/oauth/callback`

## Testing
- Could not run `go test ./internal/utils` in this environment because Go is not installed (`go: command not found`).
- Added focused unit test cases in `callback_url_util_test.go` to validate the two documented wildcard examples.

## Related
Fixes #1365