### PR TITLE
feat: add TRUSTED_PLATFORM environment variable for gin

### DIFF
--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -49,6 +49,10 @@ func initRouter(db *gorm.DB, svc *services) (utils.Service, error) {
 		_ = r.SetTrustedProxies(nil)
 	}
 
+	if common.EnvConfig.TrustedPlatform != "" {
+		r.TrustedPlatform = common.EnvConfig.TrustedPlatform
+	}
+
 	if common.EnvConfig.TracingEnabled {
 		r.Use(otelgin.Middleware(common.Name))
 	}

--- a/backend/internal/common/env_config.go
+++ b/backend/internal/common/env_config.go
@@ -44,6 +44,7 @@ type EnvConfigSchema struct {
 	DbProvider            DbProvider
 	DbConnectionString    string `env:"DB_CONNECTION_STRING" options:"file"`
 	TrustProxy            bool   `env:"TRUST_PROXY"`
+	TrustedPlatform       string `env:"TRUSTED_PLATFORM"`
 	AuditLogRetentionDays int    `env:"AUDIT_LOG_RETENTION_DAYS"`
 	AnalyticsDisabled     bool   `env:"ANALYTICS_DISABLED"`
 	AllowDowngrade        bool   `env:"ALLOW_DOWNGRADE"`


### PR DESCRIPTION
The current `TRUST_PROXY` environment variable can only control gin's `SetTrustedProxies` logic. However, gin's ClientIP logic is quite complex and cannot obtain the accurate client IP in some scenarios.

This PR is similar to #265, but it solves the problem using a more convenient variable, [see here](https://github.com/gin-gonic/gin/blob/3e44fdc4d1636a2b1599c6688a76e13216a413dd/context.go#L977) .