### PR TITLE
fix: avoid fmt.Sprintf on custom GeoLiteDBUrl without %s placeholder

### DIFF
--- a/backend/internal/service/geolite_service.go
+++ b/backend/internal/service/geolite_service.go
@@ -14,6 +14,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -112,7 +113,11 @@ func (s *GeoLiteService) UpdateDatabase(parentCtx context.Context) error {
 	}
 
 	slog.Info("Updating GeoLite2 City database")
-	downloadUrl := fmt.Sprintf(common.EnvConfig.GeoLiteDBUrl, common.EnvConfig.MaxMindLicenseKey)
+
+	downloadUrl := common.EnvConfig.GeoLiteDBUrl
+	if strings.Contains(downloadUrl, "%s") {
+		downloadUrl = fmt.Sprintf(downloadUrl, common.EnvConfig.MaxMindLicenseKey)
+	}
 
 	ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
 	defer cancel()


### PR DESCRIPTION
When `GEOLITE_DB_URL` is set to a custom URL without a `%s` placeholder, `fmt.Sprintf` produces a URL with `%!(EXTRA string=...)` appended, causing the download to fail.

This change only applies `fmt.Sprintf` when the URL contains `%s`. Since `%s` is not valid percent-encoding in a URL, this check is reliable in this context.