### PR TITLE
feat: add `token_endpoint_auth_methods_supported` to `.well-known`

### DIFF
--- a/backend/internal/controller/well_known_controller.go
+++ b/backend/internal/controller/well_known_controller.go
@@ -91,7 +91,7 @@ func (wkc *WellKnownController) computeOIDCConfiguration() ([]byte, error) {
 		"id_token_signing_alg_values_supported":          []string{alg.String()},
 		"authorization_response_iss_parameter_supported": true,
 		"code_challenge_methods_supported":               []string{"plain", "S256"},
-		"token_endpoint_auth_methods_supported":          []string{"client_secret_basic", "client_secret_post"},
+		"token_endpoint_auth_methods_supported":          []string{"client_secret_basic", "client_secret_post", "none"},
 	}
 	return json.Marshal(config)
 }


### PR DESCRIPTION
This adds the `token_endpoint_auth_methods_supported` field from [RFC 8418](https://www.rfc-editor.org/rfc/rfc8414#:~:text=token%5Fendpoint%5Fauth%5Fmethods%5Fsupported).

This field identifies which authentication methods are available for the token endpoint. This field is optional, but seems to be required for various services (such as EMQX).

Available methods are listed in [RFC 7591, section 2](https://www.rfc-editor.org/rfc/rfc7591#section-2).