### PR TITLE
fix(storage): strip Root prefix from S3 List() returned paths

### DIFF
--- a/backend/internal/storage/s3.go
+++ b/backend/internal/storage/s3.go
@@ -138,13 +138,20 @@ func (s *s3Storage) List(ctx context.Context, path string) ([]ObjectInfo, error)
 				continue
 			}
 			objects = append(objects, ObjectInfo{
-				Path:    aws.ToString(obj.Key),
+				Path:    s.pathFromKey(aws.ToString(obj.Key)),
 				Size:    aws.ToInt64(obj.Size),
 				ModTime: aws.ToTime(obj.LastModified),
 			})
 		}
 	}
 	return objects, nil
+}
+
+func (s *s3Storage) pathFromKey(key string) string {
+	if s.prefix == "" {
+		return key
+	}
+	return strings.TrimPrefix(key, s.prefix+"/")
 }
 
 func (s *s3Storage) Walk(ctx context.Context, root string, fn func(ObjectInfo) error) error {

--- a/backend/internal/storage/s3_test.go
+++ b/backend/internal/storage/s3_test.go
@@ -35,6 +35,50 @@ func TestS3Helpers(t *testing.T) {
 		}
 	})
 
+	t.Run("pathFromKey strips prefix to honor relative-path contract", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			prefix   string
+			key      string
+			expected string
+		}{
+			{name: "no prefix returns key unchanged", prefix: "", key: "images/logo.png", expected: "images/logo.png"},
+			{name: "no prefix empty key", prefix: "", key: "", expected: ""},
+			{name: "prefix matches and is stripped", prefix: "data/uploads", key: "data/uploads/application-images/logo.svg", expected: "application-images/logo.svg"},
+			{name: "single-segment prefix stripped", prefix: "root", key: "root/foo/bar.txt", expected: "foo/bar.txt"},
+			{name: "prefix as exact key returns empty rest", prefix: "root", key: "root", expected: "root"},
+			{name: "key without expected prefix returned unchanged", prefix: "data/uploads", key: "other/path.txt", expected: "other/path.txt"},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				s := &s3Storage{
+					bucket: "bucket",
+					prefix: tc.prefix,
+				}
+				assert.Equal(t, tc.expected, s.pathFromKey(tc.key))
+			})
+		}
+	})
+
+	t.Run("pathFromKey is the inverse of buildObjectKey for clean paths", func(t *testing.T) {
+		paths := []string{
+			"images/logo.png",
+			"application-images/logo.svg",
+			"oidc-client-images/abc.png",
+			"deeply/nested/file.bin",
+		}
+		prefixes := []string{"", "root", "data/uploads"}
+
+		for _, prefix := range prefixes {
+			for _, p := range paths {
+				s := &s3Storage{bucket: "bucket", prefix: prefix}
+				assert.Equal(t, p, s.pathFromKey(s.buildObjectKey(p)),
+					"round-trip failed for prefix=%q path=%q", prefix, p)
+			}
+		}
+	})
+
 	t.Run("isS3NotFound detects expected errors", func(t *testing.T) {
 		assert.True(t, isS3NotFound(&smithy.GenericAPIError{Code: "NoSuchKey"}))
 		assert.True(t, isS3NotFound(&smithy.GenericAPIError{Code: "NotFound"}))

--- a/backend/internal/storage/s3_test.go
+++ b/backend/internal/storage/s3_test.go
@@ -46,7 +46,7 @@ func TestS3Helpers(t *testing.T) {
 			{name: "no prefix empty key", prefix: "", key: "", expected: ""},
 			{name: "prefix matches and is stripped", prefix: "data/uploads", key: "data/uploads/application-images/logo.svg", expected: "application-images/logo.svg"},
 			{name: "single-segment prefix stripped", prefix: "root", key: "root/foo/bar.txt", expected: "foo/bar.txt"},
-			{name: "prefix as exact key returns empty rest", prefix: "root", key: "root", expected: "root"},
+			{name: "prefix equal to key without trailing slash is unchanged", prefix: "root", key: "root", expected: "root"},
 			{name: "key without expected prefix returned unchanged", prefix: "data/uploads", key: "other/path.txt", expected: "other/path.txt"},
 		}
 


### PR DESCRIPTION
The S3 file storage backend's List function returns full object keys including the configured Root prefix, instead of relative paths. Callers that pass listed paths back to Open or Delete double-prefix them via buildObjectKey and silently 404. This makes all configured application images (favicon, logos, background) disappear after every pod restart on S3 backends; OIDC client logos are unaffected because they bypass List.

A small pathFromKey helper strips the prefix in List so it honors the same relative-path contract as the filesystem backend. Walk inherits the fix automatically. Tests cover the strip edge cases plus a buildObjectKey/pathFromKey round-trip assertion. The same fix incidentally repairs the export service's addUploadsToZip on S3 backends, which was producing malformed zip entries and 404ing per-file Open calls for the same reason.

## Issues

Closes #1407

**Full disclosure**: I don't have any programming skills so I asked Claude Code to implement this and did my best to test it and not create AI slop. I deployed the patched image to my homelab cluster and verified the bug is fixed end-to-end against a VersityGW S3 bucket before opening this PR.
