### PR TITLE
fix: use valid Tailwind v4 transition class for auth animation squares

### DIFF
--- a/frontend/src/routes/authorize/components/client-provider-images.svelte
+++ b/frontend/src/routes/authorize/components/client-provider-images.svelte
@@ -35,7 +35,7 @@
 
 <div class="flex justify-center gap-3">
 	<div
-		class=" bg-muted transition-translate rounded-2xl p-3 duration-500 ease-in {success || error
+		class=" bg-muted transition-transform rounded-2xl p-3 duration-500 ease-in {success || error
 			? 'translate-x-[108px]'
 			: ''}"
 	>


### PR DESCRIPTION
## Summary

Fixes #1414

- `transition-translate` is not a valid Tailwind CSS v4 utility and generates no CSS output. This left the Pocket ID logo square in the authorize page animation without an explicit `transition-property`, causing the browser to fall back to `transition-property: all` (via the `duration-500` and `ease-in` utilities). As a result, layout-affecting properties were unintentionally transitioned during the DOM content swap when `animationDone` fires, causing the square to temporarily become non-square and producing a visible overlap offset.
- Replaced `transition-translate` with `transition-transform`, which is the valid Tailwind v4 utility that transitions `transform`, `translate`, `scale`, and `rotate`.

## Test plan

- [x] Build and run Pocket ID locally
- [x] Create an OIDC client and trigger the authorize flow
- [x] Verify the two squares overlap perfectly during the success/error animation
- [x] Verify the animation is smooth (no snapping or layout jank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)