### PR TITLE
fix: improve keyboard navigation and screen-reader labels

### DIFF
--- a/frontend/src/lib/components/header/header-avatar.svelte
+++ b/frontend/src/lib/components/header/header-avatar.svelte
@@ -17,7 +17,7 @@
 </script>
 
 <DropdownMenu.Root>
-	<DropdownMenu.Trigger
+	<DropdownMenu.Trigger aria-label={m.my_account()}
 		><Avatar.Root class="size-9">
 			<Avatar.Image src={cachedProfilePicture.getUrl($userStore!.id)} />
 		</Avatar.Root></DropdownMenu.Trigger

--- a/frontend/src/lib/components/sidebar.svelte
+++ b/frontend/src/lib/components/sidebar.svelte
@@ -77,7 +77,11 @@
 	const delayUpdateLink = () => `${layout().total * ROW_STAGGER}ms`;
 </script>
 
-<nav class="text-muted-foreground grid gap-2 text-sm">
+<nav
+	class="text-muted-foreground grid gap-2 text-sm"
+	aria-label={m.settings()}
+	data-sveltekit-keepfocus
+>
 	{#each items as item, i}
 		{#if item.children?.length}
 			{@const id = groupId(item, i)}

--- a/frontend/src/lib/components/table/advanced-table.svelte
+++ b/frontend/src/lib/components/table/advanced-table.svelte
@@ -223,7 +223,16 @@
 						{/if}
 
 						{#each visibleColumns as column}
-							<Table.Head class={cn(column.sortable && 'p-0')}>
+							<Table.Head
+								class={cn(column.sortable && 'p-0')}
+								aria-sort={column.sortable
+									? requestOptions.sort?.column === column.column
+										? requestOptions.sort?.direction === 'asc'
+											? 'ascending'
+											: 'descending'
+										: 'none'
+									: undefined}
+							>
 								{#if column.sortable}
 									<Button
 										variant="ghost"

--- a/frontend/src/lib/components/ui/table/table-head.svelte
+++ b/frontend/src/lib/components/ui/table/table-head.svelte
@@ -13,6 +13,7 @@
 <th
 	bind:this={ref}
 	data-slot="table-head"
+	scope="col"
 	class={cn(
 		'text-foreground h-12 px-4 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
 		className

--- a/frontend/src/routes/login/alternative/code/+page.svelte
+++ b/frontend/src/routes/login/alternative/code/+page.svelte
@@ -68,7 +68,14 @@
 		<p class="text-muted-foreground mt-2">{m.enter_the_code_you_received_to_sign_in()}</p>
 	{/if}
 	<form onsubmit={preventDefault(authenticate)} class="w-full max-w-[450px]">
-		<Input id="Code" class="mt-7" placeholder={m.code()} bind:value={code} type="text" />
+		<Input
+			id="Code"
+			class="mt-7"
+			placeholder={m.code()}
+			aria-label={m.code()}
+			bind:value={code}
+			type="text"
+		/>
 		<div class="mt-8 flex justify-between gap-2">
 			<Button variant="secondary" class="flex-1" href={backHref}>{m.go_back()}</Button>
 			<Button class="flex-1" type="submit" {isLoading}>{m.submit()}</Button>

--- a/frontend/src/routes/login/alternative/email/+page.svelte
+++ b/frontend/src/routes/login/alternative/email/+page.svelte
@@ -63,7 +63,14 @@
 			<p class="text-muted-foreground mt-2" in:fade>
 				{m.enter_your_email_address_to_receive_an_email_with_a_login_code()}
 			</p>
-			<Input id="Email" class="mt-7" placeholder={m.your_email()} bind:value={email} type="email" />
+			<Input
+				id="Email"
+				class="mt-7"
+				placeholder={m.your_email()}
+				aria-label={m.email()}
+				bind:value={email}
+				type="email"
+			/>
 			<div class="mt-8 flex justify-between gap-2">
 				<Button variant="secondary" class="flex-1" href={'/login/alternative' + page.url.search}
 					>{m.go_back()}</Button

--- a/tests/specs/navigation.spec.ts
+++ b/tests/specs/navigation.spec.ts
@@ -1,0 +1,22 @@
+import test, { expect } from '@playwright/test';
+import { cleanupBackend } from '../utils/cleanup.util';
+
+test.beforeEach(async () => await cleanupBackend());
+
+test('settings sidebar has an accessible name', async ({ page }) => {
+	await page.goto('/settings/account');
+
+	const nav = page.getByRole('navigation', { name: 'Settings' });
+	await expect(nav).toBeVisible();
+});
+
+test('keyboard focus stays on sidebar link after navigating', async ({ page }) => {
+	await page.goto('/settings/account');
+
+	const auditLog = page.getByRole('link', { name: 'Audit Log' });
+	await auditLog.focus();
+	await page.keyboard.press('Enter');
+
+	await page.waitForURL('**/settings/audit-log');
+	await expect(auditLog).toBeFocused();
+});


### PR DESCRIPTION
## Summary

Addresses a regression where activating a settings sidebar link with Enter resets keyboard focus to the document body, forcing keyboard-only users to tab through the entire header again before they can reach the sidebar. While working on that I also fixed a handful of related accessibility gaps I ran into in the same area.

Closes #1444.

## Changes

- **Preserve focus on sidebar navigation.** The settings sidebar lives in the `/settings` layout and stays in the DOM across client-side navigations, so resetting focus to `<body>` (SvelteKit's default) is unnecessary and disorienting. Adding `data-sveltekit-keepfocus` on the `<nav>` keeps focus on the activated link. SvelteKit's built-in live-region announcer still fires, so assistive technology is still told about the navigation.
- **Give landmarks accessible names.** The settings sidebar `<nav>` now carries `aria-label={m.settings()}` so multiple navigation landmarks are distinguishable. The header account dropdown trigger (which only contains the user's avatar image) now carries `aria-label={m.my_account()}`.
- **Label the alternative login inputs.** The email and code inputs on `/login/alternative/email` and `/login/alternative/code` were previously labelled only by a placeholder, which disappears on focus. They now also expose an `aria-label`. The placeholder is kept for visual consistency with the existing login design.
- **Mark column headers as columns.** Default `scope="col"` on the shared `<th>` component.
- **Announce the current sort direction.** Sortable columns in the advanced table now set `aria-sort` to `ascending`, `descending` or `none`. Non-sortable columns set no attribute at all.

## Tests

Added `tests/specs/navigation.spec.ts` with two Playwright specs:

- The settings sidebar is reachable as a navigation landmark named "Settings".
- Pressing Enter on a sidebar link keeps focus on that link after navigation.

## How to try it out

1. Sign in.
2. Using only the keyboard, Tab to any sidebar link (for example "Audit Log") and press Enter.
3. The page navigates and the next Tab press moves to the next sidebar entry rather than restarting from the header.

No visual changes.
