### PR TITLE
fix: prevent open redirect via protocol-relative URLs

### DIFF
--- a/backend/frontend/frontend_included.go
+++ b/backend/frontend/frontend_included.go
@@ -74,7 +74,13 @@ func RegisterFrontend(router *gin.Engine, rateLimitMiddleware gin.HandlerFunc) e
 		path := strings.TrimPrefix(c.Request.URL.Path, "/")
 
 		if strings.HasSuffix(path, "/") {
-			c.Redirect(http.StatusMovedPermanently, strings.TrimRight(c.Request.URL.String(), "/"))
+			target := strings.TrimRight(c.Request.URL.String(), "/")
+			// Block protocol-relative URLs (e.g. "//evil.com") to prevent open redirect
+			if strings.HasPrefix(target, "//") {
+				c.Status(http.StatusBadRequest)
+				return
+			}
+			c.Redirect(http.StatusMovedPermanently, target)
 			return
 		}
 

--- a/backend/internal/service/one_time_access_service.go
+++ b/backend/internal/service/one_time_access_service.go
@@ -106,8 +106,8 @@ func (s *OneTimeAccessService) requestOneTimeAccessEmailInternal(ctx context.Con
 		link := common.EnvConfig.AppURL + "/lc"
 		linkWithCode := link + "/" + oneTimeAccessToken
 
-		// Add redirect path to the link
-		if strings.HasPrefix(redirectPath, "/") {
+		// Add redirect path to the link (reject protocol-relative URLs like "//evil.com")
+		if strings.HasPrefix(redirectPath, "/") && !strings.HasPrefix(redirectPath, "//") {
 			encodedRedirectPath := url.QueryEscape(redirectPath)
 			linkWithCode = linkWithCode + "?redirect=" + encodedRedirectPath
 		}


### PR DESCRIPTION
## Summary

Requesting //evil.com/ returns a 301 to //evil.com. Browsers treat double-slash URLs as protocol-relative and navigate to the external domain. The trailing-slash handler builds the redirect from the raw request URL without catching this.

Same issue in the one-time-access email redirect path — it checks that the path starts with a slash, and //evil.com qualifies.

Informational. Needs a crafted link and someone to click it.

## Changes

- Return 400 for double-slash redirect targets in the frontend handler instead of following the redirect
- Reject double-slash paths in the email redirect validation