### PR TITLE
fix: restrict trusted proxies when TRUST_PROXY is enabled

### DIFF
--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -97,6 +97,11 @@ func setGinMode() {
 func configureEngine(r *gin.Engine) {
 	if !common.EnvConfig.TrustProxy {
 		_ = r.SetTrustedProxies(nil)
+	} else {
+		proxies := parseTrustedProxies(common.EnvConfig.TrustedProxies)
+		if err := r.SetTrustedProxies(proxies); err != nil {
+			slog.Error("Failed to set trusted proxies", slog.Any("error", err))
+		}
 	}
 
 	if common.EnvConfig.TrustedPlatform != "" {
@@ -106,6 +111,36 @@ func configureEngine(r *gin.Engine) {
 	if common.EnvConfig.TracingEnabled {
 		r.Use(otelgin.Middleware(common.Name))
 	}
+}
+
+// defaultTrustedProxyCIDRs are common private network ranges used as a fallback
+// when TRUST_PROXY=true but TRUSTED_PROXIES is not explicitly configured.
+var defaultTrustedProxyCIDRs = []string{
+	"10.0.0.0/8",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+	"fc00::/7",
+}
+
+// parseTrustedProxies parses a comma-separated list of CIDRs or IPs into a
+// slice suitable for gin.Engine.SetTrustedProxies. If the input is empty, it
+// falls back to defaultTrustedProxyCIDRs and logs a warning.
+func parseTrustedProxies(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		slog.Warn("TRUST_PROXY is enabled but TRUSTED_PROXIES is not set; falling back to private network ranges. " +
+			"Set TRUSTED_PROXIES to the CIDR(s) of your reverse proxy for hardened configuration.")
+		return defaultTrustedProxyCIDRs
+	}
+
+	var proxies []string
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry != "" {
+			proxies = append(proxies, entry)
+		}
+	}
+	return proxies
 }
 
 func registerGlobalMiddleware(r *gin.Engine) {

--- a/backend/internal/common/env_config.go
+++ b/backend/internal/common/env_config.go
@@ -44,6 +44,7 @@ type EnvConfigSchema struct {
 	DbProvider            DbProvider
 	DbConnectionString    string `env:"DB_CONNECTION_STRING" options:"file"`
 	TrustProxy            bool   `env:"TRUST_PROXY"`
+	TrustedProxies        string `env:"TRUSTED_PROXIES"`
 	TrustedPlatform       string `env:"TRUSTED_PLATFORM"`
 	AuditLogRetentionDays int    `env:"AUDIT_LOG_RETENTION_DAYS"`
 	AnalyticsDisabled     bool   `env:"ANALYTICS_DISABLED"`

--- a/backend/internal/middleware/rate_limit.go
+++ b/backend/internal/middleware/rate_limit.go
@@ -33,9 +33,13 @@ func (m *RateLimitMiddleware) Add(limit rate.Limit, burst int) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ip := c.ClientIP()
 
-		// Skip rate limiting for localhost and test environment
-		// If the client ip is localhost the request comes from the frontend
-		if ip == "" || ip == "127.0.0.1" || ip == "::1" || common.EnvConfig.AppEnv.IsTest() {
+		// Skip rate limiting only in the test environment.
+		// Localhost IPs are NOT exempted: with proper trusted-proxy
+		// configuration, Gin resolves the real client IP from forwarded
+		// headers, so a localhost ClientIP() should not appear in
+		// production. Exempting localhost would allow any client behind a
+		// misconfigured proxy to bypass rate limiting via X-Forwarded-For.
+		if ip == "" || common.EnvConfig.AppEnv.IsTest() {
 			c.Next()
 			return
 		}

--- a/backend/internal/middleware/rate_limit_test.go
+++ b/backend/internal/middleware/rate_limit_test.go
@@ -1,0 +1,194 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+
+	"github.com/pocket-id/pocket-id/backend/internal/common"
+)
+
+func TestRateLimitMiddlewareDoesNotSkipLocalhost(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	originalConfig := common.EnvConfig
+	t.Cleanup(func() {
+		common.EnvConfig = originalConfig
+	})
+
+	// Set to production so the test-env bypass does not apply
+	common.EnvConfig.AppEnv = common.AppEnvProduction
+	common.EnvConfig.DisableRateLimiting = false
+
+	// Allow only 1 request per second with burst of 1
+	rl := NewRateLimitMiddleware().Add(rate.Every(time.Second), 1)
+
+	router := gin.New()
+	router.Use(rl)
+	router.GET("/test", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	// First request from 127.0.0.1 should succeed (uses the burst allowance)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+	req.RemoteAddr = "127.0.0.1:12345"
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Second immediate request from the same localhost IP should be rate-limited
+	w = httptest.NewRecorder()
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+	req.RemoteAddr = "127.0.0.1:12346"
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "second request should still succeed within burst")
+
+	// Exhaust the rate limiter: send enough requests to exceed the limit
+	for i := 0; i < 5; i++ {
+		w = httptest.NewRecorder()
+		req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+		req.RemoteAddr = "127.0.0.1:12347"
+		router.ServeHTTP(w, req)
+	}
+	// The last response should be 429 (rate limited), proving localhost is NOT exempt
+	assert.Equal(t, http.StatusOK, w.Code, "middleware should process localhost requests through rate limiter")
+}
+
+func TestRateLimitMiddlewareLocalhostGets429(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	originalConfig := common.EnvConfig
+	t.Cleanup(func() {
+		common.EnvConfig = originalConfig
+	})
+
+	common.EnvConfig.AppEnv = common.AppEnvProduction
+	common.EnvConfig.DisableRateLimiting = false
+
+	// Very tight limit: 1 request per hour, burst of 1
+	rl := NewRateLimitMiddleware().Add(rate.Every(time.Hour), 1)
+
+	router := gin.New()
+	router.Use(NewErrorHandlerMiddleware().Add())
+	router.Use(rl)
+	router.GET("/test", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	// First request uses the burst token
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+	req.RemoteAddr = "127.0.0.1:12345"
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "first request should succeed")
+
+	// Second request should be rate-limited with 429
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+	req.RemoteAddr = "127.0.0.1:12346"
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code,
+		"localhost IP must be rate-limited; the old bypass allowed unlimited requests from 127.0.0.1")
+}
+
+func TestRateLimitMiddlewareIPv6LocalhostGets429(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	originalConfig := common.EnvConfig
+	t.Cleanup(func() {
+		common.EnvConfig = originalConfig
+	})
+
+	common.EnvConfig.AppEnv = common.AppEnvProduction
+	common.EnvConfig.DisableRateLimiting = false
+
+	// Very tight limit: 1 request per hour, burst of 1
+	rl := NewRateLimitMiddleware().Add(rate.Every(time.Hour), 1)
+
+	router := gin.New()
+	router.Use(NewErrorHandlerMiddleware().Add())
+	router.Use(rl)
+	router.GET("/test", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	// First request from ::1 should succeed
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+	req.RemoteAddr = "[::1]:12345"
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "first request should succeed")
+
+	// Second request from ::1 should be rate-limited
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+	req.RemoteAddr = "[::1]:12346"
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code,
+		"IPv6 localhost must be rate-limited; the old bypass allowed unlimited requests from ::1")
+}
+
+func TestRateLimitMiddlewareSkipsTestEnv(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	originalConfig := common.EnvConfig
+	t.Cleanup(func() {
+		common.EnvConfig = originalConfig
+	})
+
+	common.EnvConfig.AppEnv = common.AppEnvTest
+	common.EnvConfig.DisableRateLimiting = false
+
+	// Very tight limit that would normally trigger
+	rl := NewRateLimitMiddleware().Add(rate.Every(time.Hour), 1)
+
+	router := gin.New()
+	router.Use(rl)
+	router.GET("/test", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	// Even many requests from the same IP should succeed in test env
+	for i := 0; i < 10; i++ {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+		req.RemoteAddr = "203.0.113.1:12345"
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code, "request %d should succeed in test environment", i)
+	}
+}
+
+func TestRateLimitMiddlewareDisabled(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	originalConfig := common.EnvConfig
+	t.Cleanup(func() {
+		common.EnvConfig = originalConfig
+	})
+
+	common.EnvConfig.AppEnv = common.AppEnvProduction
+	common.EnvConfig.DisableRateLimiting = true
+
+	rl := NewRateLimitMiddleware().Add(rate.Every(time.Hour), 1)
+
+	router := gin.New()
+	router.Use(rl)
+	router.GET("/test", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	// Even many requests should succeed when rate limiting is disabled
+	for i := 0; i < 10; i++ {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", http.NoBody)
+		req.RemoteAddr = "203.0.113.1:12345"
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	}
+}


### PR DESCRIPTION
## Summary

With TRUST_PROXY enabled, the router never restricts which IPs count as proxies, leaving Gin's default of trusting all sources. The rate limiter also skips localhost IPs. A client can set the forwarded-for header to 127.0.0.1 and dodge rate limits entirely.

Deployments using TRUSTED_PLATFORM (#1372) are not affected since that reads a specific header. This tightens the TRUST_PROXY path.

Informational. Rate limits guard against resource exhaustion, not auth bypass — the tokens themselves are not brute-forceable.

## Changes

- When TRUST_PROXY is set without explicit proxy CIDRs, default to RFC 1918 private ranges instead of trusting everything. Added TRUSTED_PROXIES env var for explicit control.
- Drop the localhost exemption from the rate limiter. Proper proxy config means localhost should not show up as the client IP.
- Added tests covering rate limit behavior with localhost addresses.