### PR TITLE
fix: add missing /api prefix to app config swagger routes

### DIFF
--- a/backend/internal/controller/app_config_controller.go
+++ b/backend/internal/controller/app_config_controller.go
@@ -49,7 +49,7 @@ type AppConfigController struct {
 // @Accept json
 // @Produce json
 // @Success 200 {array} dto.PublicAppConfigVariableDto
-// @Router /application-configuration [get]
+// @Router /api/application-configuration [get]
 func (acc *AppConfigController) listAppConfigHandler(c *gin.Context) {
 	configuration := acc.appConfigService.ListAppConfig(false)
 
@@ -76,7 +76,7 @@ func (acc *AppConfigController) listAppConfigHandler(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Success 200 {array} dto.AppConfigVariableDto
-// @Router /application-configuration/all [get]
+// @Router /api/application-configuration/all [get]
 func (acc *AppConfigController) listAllAppConfigHandler(c *gin.Context) {
 	configuration := acc.appConfigService.ListAppConfig(true)
 


### PR DESCRIPTION
It looks like these 2 routes were missing `/api`, I came across this when trying to use an auto-generated client from the swagger spec which is based on the workflow the website uses https://github.com/aclerici38/pocket-id-go-client/blob/96b20c6da9d24227d89dcfe950fd6188da816f04/Makefile#L20-L33

thanks!