### PR TITLE
fix: invalidate cache when changing image

### DIFF
--- a/frontend/src/routes/settings/admin/oidc-clients/[id]/+page.svelte
+++ b/frontend/src/routes/settings/admin/oidc-clients/[id]/+page.svelte
@@ -14,6 +14,7 @@
 	import clientSecretStore from '$lib/stores/client-secret-store';
 	import type { OidcClientCreateWithLogo } from '$lib/types/oidc.type';
 	import type { ScimServiceProviderCreate } from '$lib/types/scim.type';
+	import { cachedOidcClientLogo } from '$lib/utils/cached-image-util';
 	import { axiosErrorToast } from '$lib/utils/error-util';
 	import { LucideChevronLeft, LucideRefreshCcw } from '@lucide/svelte';
 	import { toast } from 'svelte-sonner';
@@ -70,11 +71,18 @@
 
 		await Promise.all([dataPromise, imagePromise, darkImagePromise])
 			.then(() => {
+				if (updatedClient.logoUrl) {
+					cachedOidcClientLogo.bustCache(client.id, true);
+				}
+				if (updatedClient.darkLogoUrl) {
+					cachedOidcClientLogo.bustCache(client.id, false);
+				}
+
 				// Update the hasLogo and hasDarkLogo flags after successful upload
-				if (updatedClient.logo !== undefined) {
+				if (updatedClient.logo !== undefined || updatedClient.logoUrl !== undefined) {
 					client.hasLogo = updatedClient.logo !== null || !!updatedClient.logoUrl;
 				}
-				if (updatedClient.darkLogo !== undefined) {
+				if (updatedClient.darkLogo !== undefined || updatedClient.darkLogoUrl !== undefined) {
 					client.hasDarkLogo = updatedClient.darkLogo !== null || !!updatedClient.darkLogoUrl;
 				}
 				toast.success(m.oidc_client_updated_successfully());


### PR DESCRIPTION
Today I encountered an issue when attempting to change the Logo of a OIDC client. It saved, but didnt "persist".

This change should (and in my testing did) correctly invalidate the cache when changing a clients logo so that the new image is visible immediately and doesnt change back to the old one randomly.

This seems to specifically happen when when one uses URLs, so for example pastes in the URL from dashboardicons or similar.