### PR TITLE
feat: support systemd socket activation

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/smithy-go v1.25.0
 	github.com/caarlos0/env/v11 v11.4.0
 	github.com/cenkalti/backoff/v5 v5.0.3
+	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
 	github.com/disintegration/imageorient v0.0.0-20180920195336-8147d86e83ec
 	github.com/disintegration/imaging v1.6.2
 	github.com/dunglas/go-urlpattern v0.0.0-20241020164140-716dfa1c80b1

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -65,6 +65,8 @@ github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
+github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/coreos/go-systemd/activation"
 	"github.com/fsnotify/fsnotify"
 	sloggin "github.com/gin-contrib/slog"
 	"github.com/gin-gonic/gin"
@@ -165,15 +166,36 @@ func initServer(r *gin.Engine) (*serverConfig, error) {
 		return nil, err
 	}
 
-	network, addr := listenerNetworkAndAddr()
-	listener, err := net.Listen(network, addr) //nolint:noctx
-	if err != nil {
-		return nil, fmt.Errorf("failed to create %s listener: %w", network, err)
-	}
+	var addr string
+	var listener net.Listener
+	if common.EnvConfig.SystemdSocket {
+		listeners, err := activation.Listeners()
+		if err != nil {
+			return nil, fmt.Errorf("failed to receive socket from systemd: %w", err)
+		}
 
-	if err := setUnixSocketMode(network, addr); err != nil {
-		listener.Close()
-		return nil, err
+		if len(listeners) == 0 {
+			return nil, errors.New("did not receive any sockets from systemd")
+		}
+
+		if len(listeners) > 1 {
+			return nil, errors.New("received too many sockets from systemd")
+		}
+
+		addr = "(systemd)"
+		listener = listeners[0]
+	} else {
+		var network string
+		network, addr = listenerNetworkAndAddr()
+		listener, err = net.Listen(network, addr) //nolint:noctx
+		if err != nil {
+			return nil, fmt.Errorf("failed to create %s listener: %w", network, err)
+		}
+
+		if err := setUnixSocketMode(network, addr); err != nil {
+			listener.Close()
+			return nil, err
+		}
 	}
 
 	return &serverConfig{
@@ -233,7 +255,6 @@ func listenerNetworkAndAddr() (string, string) {
 	if common.EnvConfig.UnixSocket == "" {
 		return "tcp", net.JoinHostPort(common.EnvConfig.Host, common.EnvConfig.Port)
 	}
-
 	addr := common.EnvConfig.UnixSocket
 	os.Remove(addr) // remove dangling the socket file to avoid file-exist error
 	return "unix", addr

--- a/backend/internal/bootstrap/router_bootstrap.go
+++ b/backend/internal/bootstrap/router_bootstrap.go
@@ -166,45 +166,25 @@ func initServer(r *gin.Engine) (*serverConfig, error) {
 		return nil, err
 	}
 
-	var addr string
-	var listener net.Listener
+	var socketFn func() (*socket, error)
 	if common.EnvConfig.SystemdSocket {
-		listeners, err := activation.Listeners()
-		if err != nil {
-			return nil, fmt.Errorf("failed to receive socket from systemd: %w", err)
-		}
-
-		if len(listeners) == 0 {
-			return nil, errors.New("did not receive any sockets from systemd")
-		}
-
-		if len(listeners) > 1 {
-			return nil, errors.New("received too many sockets from systemd")
-		}
-
-		addr = "(systemd)"
-		listener = listeners[0]
+		socketFn = systemdSocket
+	} else if common.EnvConfig.UnixSocket != "" {
+		socketFn = unixSocket
 	} else {
-		var network string
-		network, addr = listenerNetworkAndAddr()
-		listener, err = net.Listen(network, addr) //nolint:noctx
-		if err != nil {
-			return nil, fmt.Errorf("failed to create %s listener: %w", network, err)
-		}
-
-		if err := setUnixSocketMode(network, addr); err != nil {
-			listener.Close()
-			return nil, err
-		}
+		socketFn = tcpSocket
 	}
 
-	return &serverConfig{
-		addr:         addr,
-		certProvider: certProvider,
-		listener:     listener,
-		server:       newHTTPServer(r, protocols),
-		tlsConfig:    tlsConfig,
-	}, nil
+	socket, err := socketFn()
+	if err != nil {
+		return nil, err
+	}
+
+	addr := socket.addr
+	listener := socket.listener
+	server := newHTTPServer(r, protocols)
+
+	return &serverConfig{addr, certProvider, listener, server, tlsConfig}, nil
 }
 
 func initServerProtocols() (*http.Protocols, *tls.Config, *tlsCertProvider, error) {
@@ -232,6 +212,64 @@ func initServerProtocols() (*http.Protocols, *tls.Config, *tlsCertProvider, erro
 	return protocols, tlsConfig, certProvider, nil
 }
 
+type socket struct {
+	addr     string
+	listener net.Listener
+}
+
+func systemdSocket() (*socket, error) {
+	listeners, err := activation.Listeners()
+	if err != nil {
+		return nil, fmt.Errorf("failed to receive socket from systemd: %w", err)
+	}
+
+	if len(listeners) == 0 {
+		return nil, errors.New("did not receive any sockets from systemd")
+	}
+
+	if len(listeners) > 1 {
+		return nil, errors.New("received too many sockets from systemd")
+	}
+
+	return &socket{"(systemd)", listeners[0]}, nil
+}
+
+func unixSocket() (*socket, error) {
+	addr := common.EnvConfig.UnixSocket
+	os.Remove(addr) // remove dangling the socket file to avoid file-exist error
+
+	listener, err := net.Listen("unix", addr) //nolint:noctx
+	if err != nil {
+		return nil, fmt.Errorf("failed to create UNIX socket: %w", err)
+	}
+
+	if common.EnvConfig.UnixSocketMode != "" {
+		mode, err := strconv.ParseUint(common.EnvConfig.UnixSocketMode, 8, 32)
+		if err != nil {
+			listener.Close()
+			return nil, fmt.Errorf("failed to parse UNIX socket mode '%s': %w", common.EnvConfig.UnixSocketMode, err)
+		}
+
+		if err := os.Chmod(addr, os.FileMode(mode)); err != nil {
+			listener.Close()
+			return nil, fmt.Errorf("failed to set UNIX socket mode '%s': %w", common.EnvConfig.UnixSocketMode, err)
+		}
+	}
+
+	return &socket{addr, listener}, nil
+}
+
+func tcpSocket() (*socket, error) {
+	addr := net.JoinHostPort(common.EnvConfig.Host, common.EnvConfig.Port)
+
+	listener, err := net.Listen("tcp", addr) //nolint:noctx
+	if err != nil {
+		return nil, fmt.Errorf("failed to create TCP socket: %w", err)
+	}
+
+	return &socket{addr, listener}, nil
+}
+
 func newHTTPServer(r *gin.Engine, protocols *http.Protocols) *http.Server {
 	return &http.Server{
 		MaxHeaderBytes:    1 << 20,
@@ -249,32 +287,6 @@ func newHTTPServer(r *gin.Engine, protocols *http.Protocols) *http.Server {
 			r.ServeHTTP(w, req)
 		}), &http2.Server{}),
 	}
-}
-
-func listenerNetworkAndAddr() (string, string) {
-	if common.EnvConfig.UnixSocket == "" {
-		return "tcp", net.JoinHostPort(common.EnvConfig.Host, common.EnvConfig.Port)
-	}
-	addr := common.EnvConfig.UnixSocket
-	os.Remove(addr) // remove dangling the socket file to avoid file-exist error
-	return "unix", addr
-}
-
-func setUnixSocketMode(network, addr string) error {
-	if network != "unix" || common.EnvConfig.UnixSocketMode == "" {
-		return nil
-	}
-
-	mode, err := strconv.ParseUint(common.EnvConfig.UnixSocketMode, 8, 32)
-	if err != nil {
-		return fmt.Errorf("failed to parse UNIX socket mode '%s': %w", common.EnvConfig.UnixSocketMode, err)
-	}
-
-	if err := os.Chmod(addr, os.FileMode(mode)); err != nil {
-		return fmt.Errorf("failed to set UNIX socket mode '%s': %w", common.EnvConfig.UnixSocketMode, err)
-	}
-
-	return nil
 }
 
 func runServer(ctx context.Context, config *serverConfig) error {

--- a/backend/internal/common/env_config.go
+++ b/backend/internal/common/env_config.go
@@ -68,6 +68,7 @@ type EnvConfigSchema struct {
 	Host            string `env:"HOST" options:"toLower"`
 	UnixSocket      string `env:"UNIX_SOCKET"`
 	UnixSocketMode  string `env:"UNIX_SOCKET_MODE"`
+	SystemdSocket   bool   `env:"SYSTEMD_SOCKET"`
 	LocalIPv6Ranges string `env:"LOCAL_IPV6_RANGES"`
 
 	TLSCertFile string `env:"TLS_CERT" options:"file"`
@@ -152,6 +153,9 @@ func ValidateEnvConfig(config *EnvConfigSchema) error {
 	}
 	if err := validateFileBackend(config); err != nil {
 		return err
+	}
+	if config.SystemdSocket && config.UnixSocket != "" {
+		return errors.New("SYSTEMD_SOCKET and UNIX_SOCKET are mutually exclusive")
 	}
 	if err := validateLocalIPv6Ranges(config.LocalIPv6Ranges); err != nil {
 		return err


### PR DESCRIPTION
This adds support for [systemd socket activation](https://0pointer.de/blog/projects/socket-activation.html). In this mode, Pocket ID is not responsible for creating its listening socket; instead receiving one from systemd, fully prepared and ready to use from the moment it starts up. This confers various benefits, such as simpler and more robust network bringup code, and the ability to launch Pocket ID on demand (upon receiving a connection). However, what I am personally most interested in is the flexibility it allows for customizing the socket itself, and how this customization can make sandboxing more ergonomic.

As a concrete example: I am running Pocket ID in a strongly locked-down configuration, making use of many of [systemd's hardening options](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#Sandboxing) to do so. One of these options, `PrivateUsers=`, abstracts over Linux *user namespaces* — a widely-used sandboxing technology, which is used by (and indeed fundamental to) container security. User namespaces isolate processes from the user table of the host system, making it more difficult for a compromised program to cause damage to the rest of the system.

Additionally, I am reverse-proxying Pocket ID behind Caddy.

I would like to expose Pocket ID such that its socket is only accessible to Caddy, and not to any other (unprivileged) processes. One simple way I can achieve this is by using a UNIX socket: by setting its *group* to `caddy`, and its *mode* to `0660` (i.e., user & group have read/write permissions; everyone else have no privileges). Whilst Pocket ID has no built-in support for setting the group of its socket, this can be accomplished in other ways, such as by adding a *default ACL* of `u:caddy:rw` to the containing directory. However, inside of a user namespace, this is no longer possible: from Pocket ID's perspective, the `caddy` user/group do not exist!

Along to the rescue come systemd socket units. I can define a simple configuration in **pocket-id.socket**:

```ini
[Unit]
Description=Pocket ID Socket

[Socket]
ListenStream=/run/pocket-id/socket
SocketGroup=caddy
SocketMode=0660

[Install]
WantedBy=sockets.target
```

And now I can run Pocket ID with full sandboxing, without any messy hacks or workarounds necessary. I'm sure that others would also like to be able to do this, as this feature has been [requested previously](https://github.com/pocket-id/pocket-id/pull/615#issuecomment-2943904318). It's quite useful!

Personally, I want Pocket ID to be running all the time, and not only after systemd detects something trying to connect to its socket, so I also have this in my **pocket-id.service**:

```ini
[Unit]
Requires=pocket-id.socket
After=pocket-id.socket
```

And now the socket is created whenever I start Pocket ID.

You might note that I chose to add a new configuration variable, `SYSTEMD_SOCKET`, which enables this feature. The reason I chose to do this instead of simply autodetecting when socket activation is being used (which is possible, through testing for the presence of the `LISTEN_FDS` and `LISTEN_PID` environment variables) is that in the event of misconfiguration, I have to imagine that most people wouldn't want Pocket ID to quietly start listening on a TCP socket instead. I certainly wouldn't! With this flag, it will loudly complain if something is amiss, instead of "failing open".

Lastly, I cleaned up the listener creation code a bit. It seemed to me that the logic around that had been abstracted wrongly, with too much effort placed on deduplicating certain code paths, and had turned into somewhat of a mess as a result. I reorganized it in the way that makes the most sense to me, and I think it's a lot simpler and easier to read now. I hope this is okay to roll into the same pull request!