### PR TITLE
feat: add passkey autofill login

### DIFF
--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -2,12 +2,18 @@
 	import { goto } from '$app/navigation';
 	import SignInWrapper from '$lib/components/login-wrapper.svelte';
 	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
 	import { m } from '$lib/paraglide/messages';
 	import WebAuthnService from '$lib/services/webauthn-service';
 	import appConfigStore from '$lib/stores/application-configuration-store';
 	import userStore from '$lib/stores/user-store';
 	import { getWebauthnErrorMessage } from '$lib/utils/error-util';
-	import { startAuthentication } from '@simplewebauthn/browser';
+	import {
+		browserSupportsWebAuthnAutofill,
+		startAuthentication,
+		type AuthenticationResponseJSON
+	} from '@simplewebauthn/browser';
+	import { onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { cn } from 'tailwind-variants';
 	import LoginLogoErrorSuccessIndicator from './components/login-logo-error-success-indicator.svelte';
@@ -19,16 +25,51 @@
 	let isLoading = $state(false);
 	let error: string | undefined = $state(undefined);
 
+	onMount(() => {
+		void authenticateWithPasskeyAutofill();
+	});
+
+	async function finishAuthentication(authResponse: AuthenticationResponseJSON) {
+		const user = await webauthnService.finishLogin(authResponse);
+
+		await userStore.setUser(user);
+		goto(data.redirect || '/settings');
+	}
+
+	async function authenticateWithPasskeyAutofill() {
+		let supportsAutofill = false;
+		try {
+			supportsAutofill = await browserSupportsWebAuthnAutofill();
+		} catch {
+			return;
+		}
+		if (!supportsAutofill) return;
+
+		let authResponse: AuthenticationResponseJSON;
+		try {
+			const loginOptions = await webauthnService.getLoginOptions();
+			authResponse = await startAuthentication({
+				optionsJSON: loginOptions,
+				useBrowserAutofill: true
+			});
+		} catch {
+			return;
+		}
+
+		try {
+			await finishAuthentication(authResponse);
+		} catch (e) {
+			error = getWebauthnErrorMessage(e);
+		}
+	}
+
 	async function authenticate() {
 		error = undefined;
 		isLoading = true;
 		try {
 			const loginOptions = await webauthnService.getLoginOptions();
 			const authResponse = await startAuthentication({ optionsJSON: loginOptions });
-			const user = await webauthnService.finishLogin(authResponse);
-
-			await userStore.setUser(user);
-			goto(data.redirect || '/settings');
+			await finishAuthentication(authResponse);
 		} catch (e) {
 			error = getWebauthnErrorMessage(e);
 		}
@@ -56,6 +97,15 @@
 			{m.authenticate_with_passkey_to_access_account()}
 		</p>
 	{/if}
+	<div class="mt-7 w-full max-w-[450px]">
+		<Input
+			type="text"
+			autocomplete="username webauthn"
+			placeholder={m.passkeys()}
+			aria-label={m.passkeys()}
+			autofocus={true}
+		/>
+	</div>
 	<div class="mt-10 flex justify-center gap-3 w-full max-w-[450px]">
 		{#if $appConfigStore.allowUserSignups === 'open'}
 			<Button class="w-[50%]" variant="secondary" href="/signup">
@@ -66,7 +116,6 @@
 			class={cn($appConfigStore.allowUserSignups === 'open' && 'w-[50%]')}
 			{isLoading}
 			onclick={authenticate}
-			autofocus={true}
 		>
 			{error ? m.try_again() : m.authenticate()}
 		</Button>

--- a/tests/specs/account-settings.spec.ts
+++ b/tests/specs/account-settings.spec.ts
@@ -117,8 +117,7 @@ test('Generate own one time access token as non admin', async ({ page, context }
 	await page.goto('/login');
 	await (await passkeyUtil.init(page)).addPasskey('craig');
 
-	await page.getByRole('button', { name: 'Authenticate' }).click();
-	await page.waitForURL('/settings/account');
+	await authUtil.finishAuthentication(page, '/settings/account');
 
 	await page.getByRole('button', { name: 'Create' }).click();
 	const link = await page.getByTestId('login-code-link').textContent();
@@ -136,8 +135,7 @@ test('Email verification succeeds', async ({ page, context }) => {
 	await page.goto(`/verify-email?token=${token}`);
 	await (await passkeyUtil.init(page)).addPasskey('craig');
 
-	await page.getByRole('button', { name: 'Authenticate' }).click();
-	await page.waitForURL('/settings/account?emailVerificationState=success');
+	await authUtil.finishAuthentication(page, '/settings/account?emailVerificationState=success');
 
 	await expect(page.getByText('Email Verified Successfully')).toBeVisible();
 });
@@ -149,8 +147,8 @@ test('Email verification fails with expired token', async ({ page, context }) =>
 	await page.goto(`/verify-email?token=${token}`);
 	await (await passkeyUtil.init(page)).addPasskey('craig');
 
-	await page.getByRole('button', { name: 'Authenticate' }).click();
-	await page.waitForURL(
+	await authUtil.finishAuthentication(
+		page,
 		'/settings/account?emailVerificationState=Invalid+email+verification+token'
 	);
 

--- a/tests/specs/login.spec.ts
+++ b/tests/specs/login.spec.ts
@@ -1,0 +1,37 @@
+import test, { expect } from '@playwright/test';
+import { cleanupBackend } from '../utils/cleanup.util';
+
+test.beforeEach(async () => await cleanupBackend());
+
+test('login page starts passkey autofill when supported', async ({ page, context }) => {
+	await context.clearCookies();
+
+	await page.addInitScript(() => {
+		Object.defineProperty(globalThis, 'PublicKeyCredential', {
+			value: (globalThis as any).PublicKeyCredential ?? function PublicKeyCredential() {},
+			configurable: true
+		});
+		Object.defineProperty(
+			(globalThis as any).PublicKeyCredential,
+			'isConditionalMediationAvailable',
+			{
+				value: () => Promise.resolve(true),
+				configurable: true
+			}
+		);
+	});
+
+	let loginOptionsRequested = false;
+	await page.route('/api/webauthn/login/start', async (route) => {
+		loginOptionsRequested = true;
+		await route.continue();
+	});
+
+	await page.goto('/login');
+
+	await expect(page.getByRole('textbox', { name: 'Passkeys' })).toHaveAttribute(
+		'autocomplete',
+		'username webauthn'
+	);
+	await expect.poll(() => loginOptionsRequested).toBe(true);
+});

--- a/tests/utils/auth.util.ts
+++ b/tests/utils/auth.util.ts
@@ -1,17 +1,21 @@
 import type { Page } from '@playwright/test';
 import passkeyUtil from './passkey.util';
 
-async function finishAuthentication(page: Page) {
+async function finishAuthentication(page: Page, url = '/settings/**') {
+	const waitForAuthentication = page.waitForURL(url);
+
 	if (new URL(page.url()).pathname === '/login') {
-		await page
+		const clickAuthenticate = page
 			.getByRole('button', { name: 'Authenticate' })
-			.click({ timeout: 1000 })
+			.click()
 			.catch((error: unknown) => {
 				if (new URL(page.url()).pathname === '/login') throw error;
 			});
+
+		await Promise.race([waitForAuthentication, clickAuthenticate]);
 	}
 
-	await page.waitForURL('/settings/**');
+	await waitForAuthentication;
 }
 
 async function authenticate(page: Page) {
@@ -29,4 +33,4 @@ async function changeUser(page: Page, username: keyof typeof passkeyUtil.passkey
 	await finishAuthentication(page);
 }
 
-export default { authenticate, changeUser };
+export default { authenticate, changeUser, finishAuthentication };

--- a/tests/utils/auth.util.ts
+++ b/tests/utils/auth.util.ts
@@ -1,12 +1,24 @@
 import type { Page } from '@playwright/test';
 import passkeyUtil from './passkey.util';
 
+async function finishAuthentication(page: Page) {
+	if (new URL(page.url()).pathname === '/login') {
+		await page
+			.getByRole('button', { name: 'Authenticate' })
+			.click({ timeout: 1000 })
+			.catch((error: unknown) => {
+				if (new URL(page.url()).pathname === '/login') throw error;
+			});
+	}
+
+	await page.waitForURL('/settings/**');
+}
+
 async function authenticate(page: Page) {
 	await page.goto('/login');
 
 	await (await passkeyUtil.init(page)).addPasskey();
-
-	await page.getByRole('button', { name: 'Authenticate' }).click();
+	await finishAuthentication(page);
 }
 
 async function changeUser(page: Page, username: keyof typeof passkeyUtil.passkeys) {
@@ -14,8 +26,7 @@ async function changeUser(page: Page, username: keyof typeof passkeyUtil.passkey
 	await page.goto('/login');
 
 	await (await passkeyUtil.init(page)).addPasskey(username);
-	await page.getByRole('button', { name: 'Authenticate' }).click();
-	await page.waitForURL('/settings/**');
+	await finishAuthentication(page);
 }
 
 export default { authenticate, changeUser };


### PR DESCRIPTION
This PR adds WebAuthn conditional UI support to the login page so browsers and password managers can offer saved passkeys automatically when the page loads. Users can still use the existing Authenticate button when autofill is unavailable or dismissed.

The implementation only starts conditional mediation when the browser reports passkey autofill support, and it completes authentication through the existing login flow.

Refs #1376