### PR TITLE
fix: Issues with loading new  font

### DIFF
--- a/backend/.env.development-example
+++ b/backend/.env.development-example
@@ -7,3 +7,6 @@ APP_ENV=development
 APP_URL=http://localhost:3000
 PORT=1411
 MAXMIND_LICENSE_KEY=your_license_key
+
+# Set the ENCRYPTION_KEY to a random sequence of characters, for example generated with `openssl rand -base64 32`
+ENCRYPTION_KEY=

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -135,7 +135,7 @@
 	--color-sidebar-ring: var(--sidebar-ring);
 
 	/* Font */
-	--font-glooock: 'glooock ', serif;
+	--font-gloock: 'gloock', serif;
 }
 
 @layer base {

--- a/frontend/src/lib/components/header/header.svelte
+++ b/frontend/src/lib/components/header/header.svelte
@@ -35,7 +35,7 @@
 				<a href="/" class="flex items-center transition-opacity hover:opacity-80">
 					<Logo class="size-8" />
 					<Separator orientation="vertical" class="h-5! bg-neutral-600 ml-2 mr-3" />
-					<h1 class="text-2xl font-glooock" data-testid="application-name">
+					<h1 class="text-2xl font-gloock" data-testid="application-name">
 						{m.settings()}
 					</h1>
 				</a>

--- a/frontend/src/lib/components/web-authn-unsupported.svelte
+++ b/frontend/src/lib/components/web-authn-unsupported.svelte
@@ -7,7 +7,7 @@
 	<div class="bg-muted mx-auto rounded-2xl p-3">
 		<Logo class="size-10" />
 	</div>
-	<p class="font-glooock mt-5 text-3xl font-bold sm:text-4xl">{m.browser_unsupported()}</p>
+	<p class="font-gloock mt-5 text-3xl font-bold sm:text-4xl">{m.browser_unsupported()}</p>
 	<p class="text-muted-foreground mt-3">
 		{m.this_browser_does_not_support_passkeys()}
 	</p>

--- a/frontend/src/routes/authorize/+page.svelte
+++ b/frontend/src/routes/authorize/+page.svelte
@@ -265,7 +265,7 @@
 {:else}
 	<SignInWrapper showAlternativeSignInMethodButton={$userStore == null}>
 		<ClientProviderImages {client} {success} error={!!errorMessage} />
-		<h1 class="font-glooock mt-5 text-3xl font-bold sm:text-4xl">
+		<h1 class="font-gloock mt-5 text-3xl font-bold sm:text-4xl">
 			{m.sign_in_to({ name: client.name })}
 		</h1>
 		{#if errorMessage}

--- a/frontend/src/routes/device/+page.svelte
+++ b/frontend/src/routes/device/+page.svelte
@@ -79,7 +79,7 @@
 			<LoginLogoErrorSuccessIndicator {success} error={!!errorMessage} />
 		{/if}
 	</div>
-	<h1 class="font-glooock mt-5 text-4xl font-bold">{m.authorize_device()}</h1>
+	<h1 class="font-gloock mt-5 text-4xl font-bold">{m.authorize_device()}</h1>
 	{#if errorMessage}
 		<p class="text-muted-foreground mt-2">
 			{errorMessage}. {m.please_try_again()}

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -44,7 +44,7 @@
 	<div class="flex justify-center">
 		<LoginLogoErrorSuccessIndicator error={!!error} />
 	</div>
-	<h1 class="font-glooock mt-5 text-3xl font-bold sm:text-4xl">
+	<h1 class="font-gloock mt-5 text-3xl font-bold sm:text-4xl">
 		{m.sign_in_to_appname({ appName: $appConfigStore.appName })}
 	</h1>
 	{#if error}

--- a/frontend/src/routes/login/alternative/+page.svelte
+++ b/frontend/src/routes/login/alternative/+page.svelte
@@ -35,7 +35,7 @@
 		<div class="bg-muted mx-auto rounded-2xl p-3">
 			<Logo class="size-10" />
 		</div>
-		<h1 class="font-glooock mt-5 text-3xl font-bold sm:text-4xl">{m.alternative_sign_in()}</h1>
+		<h1 class="font-gloock mt-5 text-3xl font-bold sm:text-4xl">{m.alternative_sign_in()}</h1>
 		<p class="text-muted-foreground mt-3">
 			{m.if_you_do_not_have_access_to_your_passkey_you_can_sign_in_using_one_of_the_following_methods()}
 		</p>

--- a/frontend/src/routes/login/alternative/code/+page.svelte
+++ b/frontend/src/routes/login/alternative/code/+page.svelte
@@ -59,7 +59,7 @@
 	<div class="flex justify-center">
 		<LoginLogoErrorSuccessIndicator error={!!error} />
 	</div>
-	<h1 class="font-glooock mt-5 text-4xl font-bold">{m.login_code()}</h1>
+	<h1 class="font-gloock mt-5 text-4xl font-bold">{m.login_code()}</h1>
 	{#if error}
 		<p class="text-muted-foreground mt-2">
 			{error}. {m.please_try_again()}

--- a/frontend/src/routes/login/alternative/email/+page.svelte
+++ b/frontend/src/routes/login/alternative/email/+page.svelte
@@ -37,7 +37,7 @@
 	<div class="flex justify-center">
 		<LoginLogoErrorSuccessIndicator {success} error={!!error} />
 	</div>
-	<h1 class="font-glooock mt-5 text-3xl font-bold sm:text-4xl">{m.email_login()}</h1>
+	<h1 class="font-gloock mt-5 text-3xl font-bold sm:text-4xl">{m.email_login()}</h1>
 	{#if error}
 		<p class="text-muted-foreground mt-2" in:fade>
 			{error}. {m.please_try_again()}

--- a/frontend/src/routes/logout/+page.svelte
+++ b/frontend/src/routes/logout/+page.svelte
@@ -34,7 +34,7 @@
 			<Logo class="size-10" />
 		</div>
 	</div>
-	<h1 class="font-glooock mt-5 text-4xl">{m.sign_out()}</h1>
+	<h1 class="font-gloock mt-5 text-4xl">{m.sign_out()}</h1>
 
 	<p class="text-muted-foreground mt-2">
 		<FormattedMessage

--- a/frontend/src/routes/signup/+page.svelte
+++ b/frontend/src/routes/signup/+page.svelte
@@ -61,7 +61,7 @@
 		<LoginLogoErrorSuccessIndicator error={!!error} />
 	</div>
 
-	<h1 class="font-glooock mt-5 text-3xl font-bold sm:text-4xl">
+	<h1 class="font-gloock mt-5 text-3xl font-bold sm:text-4xl">
 		{m.signup_to_appname({ appName: $appConfigStore.appName })}
 	</h1>
 

--- a/frontend/src/routes/signup/add-passkey/+page.svelte
+++ b/frontend/src/routes/signup/add-passkey/+page.svelte
@@ -69,7 +69,7 @@
 		<div class="flex justify-center">
 			<LoginLogoErrorSuccessIndicator error={!!error} />
 		</div>
-		<h1 class="font-glooock mt-5 text-3xl font-bold sm:text-4xl">
+		<h1 class="font-gloock mt-5 text-3xl font-bold sm:text-4xl">
 			{m.setup_your_passkey()}
 		</h1>
 		<p class="text-muted-foreground mt-2" in:fade>

--- a/frontend/src/routes/signup/setup/+page.svelte
+++ b/frontend/src/routes/signup/setup/+page.svelte
@@ -47,7 +47,7 @@
 		<LoginLogoErrorSuccessIndicator error={!!error} />
 	</div>
 
-	<h1 class="font-glooock mt-5 text-3xl font-bold sm:text-4xl">
+	<h1 class="font-gloock mt-5 text-3xl font-bold sm:text-4xl">
 		{m.signup_to_appname({ appName: $appConfigStore.appName })}
 	</h1>
 


### PR DESCRIPTION
## What does this PR do?
The new Gloock font wasn't actually loaded by the browser, because the name used was wrong. This PR fixes that.
Browsers defaulted back to their default `serif` font, which causes some styling differences in browsers.
Also, as a small addition, I've added the `ENCRYPTION_KEY` config option to the development `.env` example

## Screenshots
Old:
<img width="631" height="327" alt="image" src="https://github.com/user-attachments/assets/dc807443-fe8a-40f4-b9bf-77f3d37f7c5a" />

New:
<img width="631" height="327" alt="image" src="https://github.com/user-attachments/assets/e69b36ff-6151-4a53-ace4-96983d149d9e" />

## AI Usage
None

## Contributing Guidelines

Have you read the [Contributing Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md)?

- [x] If I'm implementing a new feature, I have opened an issue first, or commented on an existing one, to discuss the implementation details.
- [x] I have read the [AI Usage Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md#ai-usage-policy).
