### PR TITLE
docs: fix link to watchtower repo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 It's recommended to always use the latest version of Pocket ID. We will provide security updates for the latest version.
 
 > [!NOTE]  
-> Updates can be automated with e.g [Watchtower](https://github.com/containrrr/watchtower). Upgrading between non major versions is safe but you shouldn't upgrade between major versions before checking the release notes.
+> Updates can be automated with e.g [Watchtower](https://github.com/nicholas-fedor/watchtower/). Upgrading between non major versions is safe but you shouldn't upgrade between major versions before checking the release notes.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## What does this PR do?
The recently introduced link (https://github.com/pocket-id/pocket-id/commit/bb5a111e3d51ad56fc074df7083022e3d4e25369) to Watchtower is outdated, this repo has been archived end of 2025. There is an actively maintained fork and this PR changes the link to that repo. 

## Screenshots
n/a

## AI Usage
nope

## Contributing Guidelines

Have you read the [Contributing Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md)?

- [ ] If I'm implementing a new feature, I have opened an issue first, or commented on an existing one, to discuss the implementation details.
- [ ] I have read the [AI Usage Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md#ai-usage-policy).
