### PR TITLE
fix: csp violation - glook loaded as  inline data:

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -33,6 +33,16 @@ export default defineConfig((mode) => {
 			})
 		],
 
+		build: {
+			assetsInlineLimit: (filePath: string): boolean | undefined => {
+				const path = filePath.toLowerCase();
+				if (path.endsWith('.woff') || path.endsWith('.woff2')) {
+					return false
+				}
+				return undefined
+			}
+		},
+
 		server: {
 			host: process.env.HOST,
 			proxy: {


### PR DESCRIPTION

## What does this PR do?
fixes #1507 

A csp bug was introduced after the change to the gloock font.

Vite was inlining the new gloock font as base64 data into the css file, causing a csp error as data: is not permitted in the csp settings for font-src.

## Screenshots
not relevant - provided to pass bot quality check only
<img width="300" height="277" alt="captain" src="https://github.com/user-attachments/assets/62eb3c17-6b3c-41b7-bed6-482fd8af8c41" />

## AI Usage
LLM used to understand vite build provisions and settings

## Contributing Guidelines

Have you read the [Contributing Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md)?

- [x] If I'm implementing a new feature, I have opened an issue first, or commented on an existing one, to discuss the implementation details.
- [x] I have read the [AI Usage Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md#ai-usage-policy).
