### PR TITLE
feat: add description field to OIDC clients

### DIFF
--- a/backend/internal/dto/oidc_dto.go
+++ b/backend/internal/dto/oidc_dto.go
@@ -5,6 +5,7 @@ import datatype "github.com/pocket-id/pocket-id/backend/internal/model/types"
 type OidcClientMetaDataDto struct {
 	ID                       string  `json:"id"`
 	Name                     string  `json:"name"`
+	Description              *string `json:"description"`
 	HasLogo                  bool    `json:"hasLogo"`
 	HasDarkLogo              bool    `json:"hasDarkLogo"`
 	LaunchURL                *string `json:"launchURL"`
@@ -34,6 +35,7 @@ type OidcClientWithAllowedGroupsCountDto struct {
 
 type OidcClientUpdateDto struct {
 	Name                                string                   `json:"name" binding:"required,max=50" unorm:"nfc"`
+	Description                         *string                  `json:"description" binding:"omitempty,max=255"`
 	CallbackURLs                        []string                 `json:"callbackURLs" binding:"omitempty,dive,callback_url_pattern"`
 	LogoutCallbackURLs                  []string                 `json:"logoutCallbackURLs" binding:"omitempty,dive,callback_url_pattern"`
 	IsPublic                            bool                     `json:"isPublic"`

--- a/backend/internal/model/oidc.go
+++ b/backend/internal/model/oidc.go
@@ -23,6 +23,7 @@ type OidcClient struct {
 	Base
 
 	Name                                string `sortable:"true"`
+	Description                         *string `sortable:"true"`
 	Secret                              string
 	CallbackURLs                        UrlList
 	LogoutCallbackURLs                  UrlList

--- a/backend/internal/service/oidc_service.go
+++ b/backend/internal/service/oidc_service.go
@@ -213,6 +213,7 @@ func (s *OidcService) UpdateClient(ctx context.Context, clientID string, input d
 func updateOIDCClientModelFromDto(client *model.OidcClient, input *dto.OidcClientUpdateDto) {
 	// Base fields
 	client.Name = input.Name
+	client.Description = input.Description
 	client.CallbackURLs = input.CallbackURLs
 	client.LogoutCallbackURLs = input.LogoutCallbackURLs
 	client.IsPublic = input.IsPublic

--- a/backend/resources/migrations/sqlite/20250624150000_add_oidc_client_description.down.sql
+++ b/backend/resources/migrations/sqlite/20250624150000_add_oidc_client_description.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oidc_clients DROP COLUMN description;

--- a/backend/resources/migrations/sqlite/20250624150000_add_oidc_client_description.up.sql
+++ b/backend/resources/migrations/sqlite/20250624150000_add_oidc_client_description.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oidc_clients ADD COLUMN description TEXT;

--- a/frontend/src/lib/types/oidc.type.ts
+++ b/frontend/src/lib/types/oidc.type.ts
@@ -3,6 +3,7 @@ import type { UserGroup } from './user-group.type';
 export type OidcClientMetaData = {
 	id: string;
 	name: string;
+	description?: string;
 	hasLogo: boolean;
 	hasDarkLogo: boolean;
 	requiresReauthentication: boolean;

--- a/frontend/src/routes/settings/admin/oidc-clients/oidc-client-form.svelte
+++ b/frontend/src/routes/settings/admin/oidc-clients/oidc-client-form.svelte
@@ -44,6 +44,7 @@
 	const client = {
 		id: '',
 		name: existingClient?.name || '',
+		description: existingClient?.description || '',
 		callbackURLs: existingClient?.callbackURLs || [],
 		logoutCallbackURLs: existingClient?.logoutCallbackURLs || [],
 		isPublic: existingClient?.isPublic || false,
@@ -71,6 +72,7 @@
 				.optional()
 		),
 		name: z.string().min(2).max(50),
+		description: z.string().max(255).optional(),
 		callbackURLs: z.array(callbackUrlSchema).default([]),
 		logoutCallbackURLs: z.array(callbackUrlSchema).default([]),
 		isPublic: z.boolean(),
@@ -180,6 +182,12 @@
 			class="w-full"
 			description={m.client_name_description()}
 			bind:input={$inputs.name}
+		/>
+		<FormInput
+			label={m.description()}
+			class="w-full"
+			description={m.client_description_description()}
+			bind:input={$inputs.description}
 		/>
 		<FormInput
 			label={m.client_launch_url()}

--- a/frontend/src/routes/settings/apps/authorized-oidc-client-card.svelte
+++ b/frontend/src/routes/settings/apps/authorized-oidc-client-card.svelte
@@ -46,7 +46,7 @@
 				/>
 			</div>
 			<div class="flex w-full justify-between gap-3">
-				<div>
+				<div class="min-w-0">
 					<div class="mb-1 flex items-start gap-2">
 						<h3
 							class="text-foreground line-clamp-2 leading-tight font-semibold break-words break-all text-ellipsis"
@@ -54,7 +54,13 @@
 							{client.name}
 						</h3>
 					</div>
-					{#if client.launchURL}
+					{#if client.description}
+						<p
+							class="text-muted-foreground line-clamp-1 text-xs break-words break-all text-ellipsis"
+						>
+							{client.description}
+						</p>
+					{:else if client.launchURL}
 						<p
 							class="text-muted-foreground line-clamp-1 text-xs break-words break-all text-ellipsis"
 						>
@@ -75,52 +81,52 @@
 										onclick={() => goto(`/settings/admin/oidc-clients/${client.id}`)}
 										><LucidePencil class="mr-2 size-4" /> {m.edit()}</DropdownMenu.Item
 									>
-								{/if}
+									{/if}
 								{#if client.lastUsedAt}
 									<DropdownMenu.Item
 										class="text-red-500 focus:!text-red-700"
 										onclick={() => onRevoke(client)}
 										><LucideBan class="mr-2 size-4" />{m.revoke()}</DropdownMenu.Item
 									>
-								{/if}
-							</DropdownMenu.Content>
-						</DropdownMenu.Root>
-					</div>
-				{/if}
+									{/if}
+								</DropdownMenu.Content>
+							</DropdownMenu.Root>
+						</div>
+					{/if}
+				</div>
 			</div>
-		</div>
 
-		<div class="mt-2 flex items-end justify-between">
-			{#if client.lastUsedAt}
-				<Tooltip.Provider>
-					<Tooltip.Root>
-						<Tooltip.Trigger>
-							<p class="text-muted-foreground flex items-center text-xs">
-								<LucideLogIn class="mr-1 size-3" />
-								{formatDistanceToNow(client.lastUsedAt, { addSuffix: true })}
-							</p>
-						</Tooltip.Trigger>
-						<Tooltip.Content
-							>{m.last_signed_in_ago({
-								time: formatDistanceToNow(client.lastUsedAt)
-							})}</Tooltip.Content
-						>
-					</Tooltip.Root></Tooltip.Provider
+			<div class="mt-2 flex items-end justify-between">
+				{#if client.lastUsedAt}
+					<Tooltip.Provider>
+						<Tooltip.Root>
+							<Tooltip.Trigger>
+								<p class="text-muted-foreground flex items-center text-xs">
+									<LucideLogIn class="mr-1 size-3" />
+									{formatDistanceToNow(client.lastUsedAt, { addSuffix: true })}
+								</p>
+							</Tooltip.Trigger>
+							<Tooltip.Content
+								>{m.last_signed_in_ago({
+									time: formatDistanceToNow(client.lastUsedAt)
+								})}</Tooltip.Content
+							>
+						</Tooltip.Root></Tooltip.Provider
+					>
+				{:else}
+					<div></div>
+				{/if}
+				<Button
+					href={client.launchURL}
+					target="_blank"
+					size="sm"
+					class="h-8 text-xs"
+					rel="noopener noreferrer"
+					disabled={!client.launchURL}
 				>
-			{:else}
-				<div></div>
-			{/if}
-			<Button
-				href={client.launchURL}
-				target="_blank"
-				size="sm"
-				class="h-8 text-xs"
-				rel="noopener noreferrer"
-				disabled={!client.launchURL}
-			>
-				{m.launch()}
-				<LucideExternalLink class="ml-1 size-3" />
-			</Button>
-		</div>
-	</Card.Content>
-</Card.Root>
+					{m.launch()}
+					<LucideExternalLink class="ml-1 size-3" />
+				</Button>
+			</div>
+		</Card.Content>
+	</Card.Root>


### PR DESCRIPTION
Adds an optional description field to OIDC clients that displays on the My Apps page below the app name.

Changes:
- Add Description field to OidcClient model (nullable, max 255 chars)
- Update DTOs to include description
- Update service to persist description
- Add database migration for new column
- Update frontend types
- Add description input to client form
- Display description in My Apps cards (falls back to hostname if not set)

Fixes pocket-id/pocket-id#1246