### PR TITLE
tests(e2e): make API key renewal date picker navigation date-independent

### DIFF
--- a/tests/specs/api-key.spec.ts
+++ b/tests/specs/api-key.spec.ts
@@ -111,8 +111,23 @@ function getDefaultApiKeyExpirationDate() {
 
 async function selectApiKeyExpirationDate(page: Page, date: Date) {
 	await page.getByRole('button', { name: 'Select a date' }).click();
-	await page.getByRole('button', { name: 'Next', exact: true }).click();
-	await page.getByRole('button', { name: getCalendarDayName(date) }).click();
+
+	const targetDay = page.getByRole('button', { name: getCalendarDayName(date) });
+	const nextButton = page.getByRole('button', { name: 'Next', exact: true });
+
+	// The calendar opens on the month of the field's current value, which can be an
+	// arbitrary number of months away from the target date (e.g. when renewing an
+	// already-expired key, whose proposed date is in the past). Advance one month at
+	// a time until the target day is rendered, rather than assuming it is exactly one
+	// month ahead — that assumption is date-dependent and fails on most days.
+	await expect(async () => {
+		if (!(await targetDay.isVisible())) {
+			await nextButton.click();
+		}
+		await expect(targetDay).toBeVisible({ timeout: 500 });
+	}).toPass({ timeout: 8000 });
+
+	await targetDay.click();
 }
 
 function getCalendarDayName(date: Date) {


### PR DESCRIPTION
## What does this PR do?

Fixes a date-dependent flake in the `api-key.spec.ts` → **Renew API key** e2e test that fails on most calendar dates (it was failing consistently in CI as of today).

The `selectApiKeyExpirationDate` helper navigated the expiration date picker by clicking **"Next" exactly once** before selecting the target day (`today + 30 days`). But the calendar opens on the month of the field's *current* value, and for the seeded **expired** API key (`ExpiresAt = now − 20 days`) the renew modal proposes a date ~20 days in the past. So a single "Next" click only lands on the correct month on a minority of dates — on the rest, the target day isn't rendered and the click times out.

This changes the helper to advance the calendar **one month at a time until the target day is rendered**, instead of assuming it is exactly one month ahead. `expect(...).toPass()` is used so the loop is robust against re-render timing and never overshoots (it only clicks "Next" while the target day isn't visible). Timeouts stay well within the 10s per-test budget; at most two "Next" clicks are ever needed here.

No production code changes — this is a test-only fix.

## Screenshots

N/A (test-only change).

## AI Usage

This test fix was written with the assistance of Claude Code, under human review.

## Contributing Guidelines

Have you read the [Contributing Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md)?

- [x] If I'm implementing a new feature, I have opened an issue first, or commented on an existing one, to discuss the implementation details. (N/A — bug fix for a flaky test)
- [x] I have read the [AI Usage Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md#ai-usage-policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAF489fZaP97GHX6ZFGufp

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAF489fZaP97GHX6ZFGufp)_