### PR TITLE
[feat/apis-1542] Fixes for OAuth APIs/scopes

### DIFF
--- a/backend/internal/api/service.go
+++ b/backend/internal/api/service.go
@@ -177,7 +177,9 @@ func (s *Service) UpdatePermissions(ctx context.Context, id string, input apiPer
 		return API{}, err
 	}
 
-	// Reject keys with invalid characters or that collide with Pocket ID's reserved scopes and claims before persisting anything
+	// Reject keys with invalid characters, that collide with Pocket ID's reserved scopes and claims, or that repeat within the request before persisting anything
+	// A duplicate key would otherwise be silently coalesced last-wins into the map below, dropping a row behind a 200
+	seen := make(map[string]struct{}, len(input.Permissions))
 	for _, permission := range input.Permissions {
 		if !isValidPermissionKey(permission.Key) {
 			return API{}, &common.ValidationError{Message: fmt.Sprintf("the permission key %q contains invalid characters", permission.Key)}
@@ -185,6 +187,11 @@ func (s *Service) UpdatePermissions(ctx context.Context, id string, input apiPer
 		if isPermissionKeyReserved(permission.Key) {
 			return API{}, &common.ValidationError{Message: fmt.Sprintf("the permission key %q is reserved by Pocket ID", permission.Key)}
 		}
+		_, ok := seen[permission.Key]
+		if ok {
+			return API{}, &common.ValidationError{Message: fmt.Sprintf("the permission key %q is listed more than once", permission.Key)}
+		}
+		seen[permission.Key] = struct{}{}
 	}
 
 	existing := make(map[string]Permission, len(api.Permissions))

--- a/backend/internal/api/service_test.go
+++ b/backend/internal/api/service_test.go
@@ -182,6 +182,23 @@ func TestUpdatePermissionsRejectsReservedKeys(t *testing.T) {
 	}
 }
 
+func TestUpdatePermissionsRejectsDuplicateKeys(t *testing.T) {
+	db := testutils.NewDatabaseForTest(t)
+	svc := New(Dependencies{DB: db}).service
+
+	orders, err := svc.Create(t.Context(), apiCreateDto{Name: "Orders", Resource: "https://api.orders.example.com"})
+	require.NoError(t, err)
+
+	// Two rows with the same key must be rejected rather than silently coalesced last-wins
+	_, err = svc.UpdatePermissions(t.Context(), orders.ID, apiPermissionsUpdateDto{Permissions: []apiPermissionInputDto{
+		{Key: "read:orders", Name: "Read"},
+		{Key: "read:orders", Name: "Read again"},
+	}})
+	require.Error(t, err)
+	var validationErr *common.ValidationError
+	require.ErrorAs(t, err, &validationErr)
+}
+
 func TestUpdatePermissionsRejectsInvalidKeyCharacters(t *testing.T) {
 	db := testutils.NewDatabaseForTest(t)
 	svc := New(Dependencies{DB: db}).service

--- a/backend/internal/dto/oidc_dto.go
+++ b/backend/internal/dto/oidc_dto.go
@@ -89,8 +89,15 @@ type OidcDeviceAuthorizationResponseDto struct {
 	Interval                int    `json:"interval"`
 }
 
+type ScopeInfoDto struct {
+	Key         string `json:"key"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
 type DeviceCodeInfoDto struct {
 	Scope                    []string              `json:"scope"`
+	ScopeInfo                []ScopeInfoDto        `json:"scopeInfo"`
 	AuthorizationRequired    bool                  `json:"authorizationRequired"`
 	ReauthenticationRequired bool                  `json:"reauthenticationRequired"`
 	Client                   OidcClientMetaDataDto `json:"client"`

--- a/backend/internal/dto/validations.go
+++ b/backend/internal/dto/validations.go
@@ -70,6 +70,16 @@ func ValidateClientID(clientID string) bool {
 	return validateClientIDRegex.MatchString(clientID)
 }
 
+// isActiveContentScheme reports whether the URL scheme can carry executable content, so it must never be accepted where a URL might later be rendered as a link
+func isActiveContentScheme(scheme string) bool {
+	switch strings.ToLower(scheme) {
+	case "javascript", "data":
+		return true
+	default:
+		return false
+	}
+}
+
 // ValidateResourceURI validates RFC 8707 resource identifiers
 func ValidateResourceURI(str string) bool {
 	if strings.Contains(str, "#") || strings.ContainsFunc(str, unicode.IsSpace) {
@@ -78,6 +88,11 @@ func ValidateResourceURI(str string) bool {
 
 	u, err := url.Parse(str)
 	if err != nil {
+		return false
+	}
+
+	// Reject active-content schemes so a resource identifier can never carry executable content if it is ever surfaced as a link
+	if isActiveContentScheme(u.Scheme) {
 		return false
 	}
 
@@ -92,12 +107,7 @@ func ValidateCallbackURL(str string) bool {
 		return false
 	}
 
-	switch strings.ToLower(u.Scheme) {
-	case "javascript", "data":
-		return false
-	default:
-		return true
-	}
+	return !isActiveContentScheme(u.Scheme)
 }
 
 // ValidateCallbackURLPattern validates callback URL patterns, with support for wildcards.

--- a/backend/internal/dto/validations_test.go
+++ b/backend/internal/dto/validations_test.go
@@ -75,6 +75,8 @@ func TestValidateResourceURI(t *testing.T) {
 		{"invalid unescaped path space", "https://api.example.com/a b", false},
 		{"invalid unescaped opaque space", "urn:my app", false},
 		{"invalid malformed URI", "http://[::1", false},
+		{"invalid javascript scheme", "javascript:alert(1)", false},
+		{"invalid data scheme", "data:text/html,<script>alert(1)</script>", false},
 		{"empty", "", false},
 	}
 

--- a/backend/internal/oidc/access_token_scope.go
+++ b/backend/internal/oidc/access_token_scope.go
@@ -2,65 +2,58 @@ package oidc
 
 import (
 	"context"
+	"slices"
 
 	"github.com/ory/fosite"
 	fositeoauth2 "github.com/ory/fosite/handler/oauth2"
 )
 
-// targetsCustomAPI reports whether the token being materialized is audienced to a custom API rather than (only) the requesting client itself
-// Such a token is an API access token: it is handed to a third-party resource server and therefore must not carry Pocket ID's own identity scopes.
-func targetsCustomAPI(requester fosite.Requester) bool {
-	client := requester.GetClient()
-	if client == nil {
-		return false
-	}
-
-	clientID := client.GetID()
-	for _, audience := range requester.GetGrantedAudience() {
-		if audience != clientID {
-			return true
-		}
-	}
-
-	return false
+// isIdentityScope reports whether the scope is an OIDC identity scope whose presence lets a token be presented to Pocket ID's own identity endpoints such as /userinfo
+// offline_access is deliberately excluded: it only requests a refresh token and is not tied to any resource server
+func isIdentityScope(scope string) bool {
+	return scope != "offline_access" && isStandardScope(scope)
 }
 
-// withAccessTokenScopes returns a view of the requester whose granted scopes are limited to what may
-// appear on the access token
-// Identity scopes stay on the underlying grant so the ID token and consent keep working, but they are stripped from an access token audienced to a custom API: those identity claims are delivered through the ID token, and keeping them off the API access token stops it from being replayed against Pocket ID's own identity endpoints such as /userinfo.
-//
-// The returned requester leaves every other field untouched, so callers that need the full grant (e.g. ID token issuance) are unaffected.
-func withAccessTokenScopes(requester fosite.Requester) fosite.Requester {
-	if !targetsCustomAPI(requester) {
+// hasIdentityScope reports whether any of the granted scopes is an OIDC identity scope
+func hasIdentityScope(scopes fosite.Arguments) bool {
+	return slices.ContainsFunc(scopes, isIdentityScope)
+}
+
+// withIdentityAudience returns a view of the requester whose granted audience additionally includes the issuer when the token carries an identity scope
+// This lets an access token that was granted an identity scope be presented to Pocket ID's own identity endpoints such as /userinfo, even when it was also audienced to a custom API
+// The issuer is added only to the materialized access token and never to the underlying grant, so a refresh does not have to re-whitelist the issuer against the client and a machine token whose identity scopes were stripped never receives it
+func withIdentityAudience(requester fosite.Requester, issuer string) fosite.Requester {
+	if issuer == "" || !hasIdentityScope(requester.GetGrantedScopes()) {
 		return requester
 	}
 
-	granted := requester.GetGrantedScopes()
-	filtered := make(fosite.Arguments, 0, len(granted))
-	for _, scope := range granted {
-		if !isStandardScope(scope) {
-			filtered = append(filtered, scope)
-		}
+	granted := requester.GetGrantedAudience()
+	if granted.Has(issuer) {
+		return requester
 	}
 
-	return accessTokenRequester{Requester: requester, grantedScopes: filtered}
+	audience := make(fosite.Arguments, 0, len(granted)+1)
+	audience = append(audience, granted...)
+	audience = append(audience, issuer)
+	return identityAudienceRequester{Requester: requester, grantedAudience: audience}
 }
 
-// accessTokenRequester overrides only the granted scopes of the wrapped requester.
-type accessTokenRequester struct {
+// identityAudienceRequester overrides only the granted audience of the wrapped requester
+type identityAudienceRequester struct {
 	fosite.Requester
-	grantedScopes fosite.Arguments
+	grantedAudience fosite.Arguments
 }
 
-func (r accessTokenRequester) GetGrantedScopes() fosite.Arguments {
-	return r.grantedScopes
+func (r identityAudienceRequester) GetGrantedAudience() fosite.Arguments {
+	return r.grantedAudience
 }
 
-// apiAudienceAccessTokenStrategy wraps the access token strategy so the scope claim on an access token audienced to a custom API excludes identity scopes, keeping the self-contained JWT consistent with what is persisted for introspection.
-type apiAudienceAccessTokenStrategy struct {
+// identityAudienceAccessTokenStrategy wraps the access token strategy so an access token granted an identity scope also lists the issuer in its audience, keeping the self-contained JWT consistent with what is persisted for introspection and userinfo
+type identityAudienceAccessTokenStrategy struct {
 	fositeoauth2.CoreStrategy
+	issuer string
 }
 
-func (s apiAudienceAccessTokenStrategy) GenerateAccessToken(ctx context.Context, requester fosite.Requester) (string, string, error) {
-	return s.CoreStrategy.GenerateAccessToken(ctx, withAccessTokenScopes(requester))
+func (s identityAudienceAccessTokenStrategy) GenerateAccessToken(ctx context.Context, requester fosite.Requester) (string, string, error) {
+	return s.CoreStrategy.GenerateAccessToken(ctx, withIdentityAudience(requester, s.issuer))
 }

--- a/backend/internal/oidc/access_token_scope.go
+++ b/backend/internal/oidc/access_token_scope.go
@@ -1,0 +1,66 @@
+package oidc
+
+import (
+	"context"
+
+	"github.com/ory/fosite"
+	fositeoauth2 "github.com/ory/fosite/handler/oauth2"
+)
+
+// targetsCustomAPI reports whether the token being materialized is audienced to a custom API rather than (only) the requesting client itself
+// Such a token is an API access token: it is handed to a third-party resource server and therefore must not carry Pocket ID's own identity scopes.
+func targetsCustomAPI(requester fosite.Requester) bool {
+	client := requester.GetClient()
+	if client == nil {
+		return false
+	}
+
+	clientID := client.GetID()
+	for _, audience := range requester.GetGrantedAudience() {
+		if audience != clientID {
+			return true
+		}
+	}
+
+	return false
+}
+
+// withAccessTokenScopes returns a view of the requester whose granted scopes are limited to what may
+// appear on the access token
+// Identity scopes stay on the underlying grant so the ID token and consent keep working, but they are stripped from an access token audienced to a custom API: those identity claims are delivered through the ID token, and keeping them off the API access token stops it from being replayed against Pocket ID's own identity endpoints such as /userinfo.
+//
+// The returned requester leaves every other field untouched, so callers that need the full grant (e.g. ID token issuance) are unaffected.
+func withAccessTokenScopes(requester fosite.Requester) fosite.Requester {
+	if !targetsCustomAPI(requester) {
+		return requester
+	}
+
+	granted := requester.GetGrantedScopes()
+	filtered := make(fosite.Arguments, 0, len(granted))
+	for _, scope := range granted {
+		if !isStandardScope(scope) {
+			filtered = append(filtered, scope)
+		}
+	}
+
+	return accessTokenRequester{Requester: requester, grantedScopes: filtered}
+}
+
+// accessTokenRequester overrides only the granted scopes of the wrapped requester.
+type accessTokenRequester struct {
+	fosite.Requester
+	grantedScopes fosite.Arguments
+}
+
+func (r accessTokenRequester) GetGrantedScopes() fosite.Arguments {
+	return r.grantedScopes
+}
+
+// apiAudienceAccessTokenStrategy wraps the access token strategy so the scope claim on an access token audienced to a custom API excludes identity scopes, keeping the self-contained JWT consistent with what is persisted for introspection.
+type apiAudienceAccessTokenStrategy struct {
+	fositeoauth2.CoreStrategy
+}
+
+func (s apiAudienceAccessTokenStrategy) GenerateAccessToken(ctx context.Context, requester fosite.Requester) (string, string, error) {
+	return s.CoreStrategy.GenerateAccessToken(ctx, withAccessTokenScopes(requester))
+}

--- a/backend/internal/oidc/access_token_scope_test.go
+++ b/backend/internal/oidc/access_token_scope_test.go
@@ -1,0 +1,49 @@
+package oidc
+
+import (
+	"testing"
+
+	"github.com/ory/fosite"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pocket-id/pocket-id/backend/internal/model"
+)
+
+func newScopeTestRequester(clientID string, granted fosite.Arguments, audience fosite.Arguments) *fosite.Request {
+	request := fosite.NewRequest()
+	request.Client = Client{
+		OidcClient: model.OidcClient{
+			Base: model.Base{ID: clientID},
+		},
+	}
+	request.GrantedScope = granted
+	request.GrantedAudience = audience
+	return request
+}
+
+func TestTargetsCustomAPI(t *testing.T) {
+	// A login token is audienced only to the requesting client
+	assert.False(t, targetsCustomAPI(newScopeTestRequester("client-1", nil, fosite.Arguments{"client-1"})))
+	// No audience at all is not a custom API
+	assert.False(t, targetsCustomAPI(newScopeTestRequester("client-1", nil, nil)))
+	// Any audience other than the client itself means the token targets a custom API
+	assert.True(t, targetsCustomAPI(newScopeTestRequester("client-1", nil, fosite.Arguments{"https://api.example.com"})))
+	assert.True(t, targetsCustomAPI(newScopeTestRequester("client-1", nil, fosite.Arguments{"client-1", "https://api.example.com"})))
+}
+
+func TestWithAccessTokenScopesStripsIdentityScopesForCustomAPI(t *testing.T) {
+	// An access token audienced to a custom API keeps only the API scopes
+	// Because identity scopes are dropped, the token cannot be used at /userinfo
+	apiRequest := newScopeTestRequester("client-1",
+		fosite.Arguments{"openid", "profile", "email", "groups", "offline_access", "read:orders"},
+		fosite.Arguments{"https://api.orders.example.com"},
+	)
+	assert.Equal(t, fosite.Arguments{"read:orders"}, withAccessTokenScopes(apiRequest).GetGrantedScopes())
+
+	// A login token audienced to the client keeps all its scopes untouched.
+	loginRequest := newScopeTestRequester("client-1",
+		fosite.Arguments{"openid", "profile", "email"},
+		fosite.Arguments{"client-1"},
+	)
+	assert.Equal(t, fosite.Arguments{"openid", "profile", "email"}, withAccessTokenScopes(loginRequest).GetGrantedScopes())
+}

--- a/backend/internal/oidc/access_token_scope_test.go
+++ b/backend/internal/oidc/access_token_scope_test.go
@@ -21,29 +21,47 @@ func newScopeTestRequester(clientID string, granted fosite.Arguments, audience f
 	return request
 }
 
-func TestTargetsCustomAPI(t *testing.T) {
-	// A login token is audienced only to the requesting client
-	assert.False(t, targetsCustomAPI(newScopeTestRequester("client-1", nil, fosite.Arguments{"client-1"})))
-	// No audience at all is not a custom API
-	assert.False(t, targetsCustomAPI(newScopeTestRequester("client-1", nil, nil)))
-	// Any audience other than the client itself means the token targets a custom API
-	assert.True(t, targetsCustomAPI(newScopeTestRequester("client-1", nil, fosite.Arguments{"https://api.example.com"})))
-	assert.True(t, targetsCustomAPI(newScopeTestRequester("client-1", nil, fosite.Arguments{"client-1", "https://api.example.com"})))
-}
+func TestWithIdentityAudienceAddsIssuerForIdentityScopes(t *testing.T) {
+	const issuer = "https://issuer.example.com"
 
-func TestWithAccessTokenScopesStripsIdentityScopesForCustomAPI(t *testing.T) {
-	// An access token audienced to a custom API keeps only the API scopes
-	// Because identity scopes are dropped, the token cannot be used at /userinfo
+	// A token granted an identity scope alongside a custom API also lists the issuer so it can be presented to /userinfo
 	apiRequest := newScopeTestRequester("client-1",
-		fosite.Arguments{"openid", "profile", "email", "groups", "offline_access", "read:orders"},
+		fosite.Arguments{"openid", "read:orders"},
 		fosite.Arguments{"https://api.orders.example.com"},
 	)
-	assert.Equal(t, fosite.Arguments{"read:orders"}, withAccessTokenScopes(apiRequest).GetGrantedScopes())
+	assert.ElementsMatch(t,
+		fosite.Arguments{"https://api.orders.example.com", issuer},
+		withIdentityAudience(apiRequest, issuer).GetGrantedAudience(),
+	)
 
-	// A login token audienced to the client keeps all its scopes untouched.
+	// A plain login token gains the issuer audience alongside the client it was bound to
 	loginRequest := newScopeTestRequester("client-1",
 		fosite.Arguments{"openid", "profile", "email"},
 		fosite.Arguments{"client-1"},
 	)
-	assert.Equal(t, fosite.Arguments{"openid", "profile", "email"}, withAccessTokenScopes(loginRequest).GetGrantedScopes())
+	assert.ElementsMatch(t,
+		fosite.Arguments{"client-1", issuer},
+		withIdentityAudience(loginRequest, issuer).GetGrantedAudience(),
+	)
+}
+
+func TestWithIdentityAudienceLeavesNonIdentityTokensUntouched(t *testing.T) {
+	const issuer = "https://issuer.example.com"
+
+	// A token audienced only to a custom API with no identity scope never gains the issuer, so it cannot reach /userinfo
+	apiOnly := newScopeTestRequester("client-1",
+		fosite.Arguments{"read:orders"},
+		fosite.Arguments{"https://api.orders.example.com"},
+	)
+	assert.Equal(t, fosite.Arguments{"https://api.orders.example.com"}, withIdentityAudience(apiOnly, issuer).GetGrantedAudience())
+
+	// offline_access alone is not an identity scope, so it does not add the issuer either
+	offlineOnly := newScopeTestRequester("client-1",
+		fosite.Arguments{"offline_access", "read:orders"},
+		fosite.Arguments{"https://api.orders.example.com"},
+	)
+	assert.Equal(t, fosite.Arguments{"https://api.orders.example.com"}, withIdentityAudience(offlineOnly, issuer).GetGrantedAudience())
+
+	// An empty issuer disables the behavior entirely, leaving the audience untouched
+	assert.Equal(t, fosite.Arguments{"client-1"}, withIdentityAudience(newScopeTestRequester("client-1", fosite.Arguments{"openid"}, fosite.Arguments{"client-1"}), "").GetGrantedAudience())
 }

--- a/backend/internal/oidc/api_resource.go
+++ b/backend/internal/oidc/api_resource.go
@@ -2,11 +2,35 @@ package oidc
 
 import (
 	"context"
+	"net/http"
+	"net/url"
 	"slices"
 
 	"github.com/ory/fosite"
 	"gorm.io/gorm"
 )
+
+// errMultipleResources is the RFC 8707 invalid_target error returned when a request carries more than one resource parameter
+// The fork does not predefine invalid_target, so it is built here to match how fosite constructs its own errors
+var errMultipleResources = &fosite.RFC6749Error{
+	ErrorField:       "invalid_target",
+	DescriptionField: "The requested resource is invalid, missing, unknown, or malformed.",
+	HintField:        "Only a single 'resource' parameter is supported.",
+	CodeField:        http.StatusBadRequest,
+}
+
+// resourceFromForm extracts the single RFC 8707 resource identifier from a request form
+// A token is audienced to exactly one API, so a request that carries more than one resource is rejected rather than silently narrowed to the first value
+func resourceFromForm(form url.Values) (string, error) {
+	values := form["resource"]
+	if len(values) > 1 {
+		return "", errMultipleResources
+	}
+	if len(values) == 0 {
+		return "", nil
+	}
+	return values[0], nil
+}
 
 func isStandardScope(scope string) bool {
 	// standardScopes are the built-in identity scopes that any client may request

--- a/backend/internal/oidc/api_resource.go
+++ b/backend/internal/oidc/api_resource.go
@@ -8,12 +8,14 @@ import (
 	"gorm.io/gorm"
 )
 
-// standardScopes are the built-in identity scopes that any client may request
-// They are released as ID-token and userinfo claims and are always available without targeting an API
-var standardScopes = []string{"openid", "profile", "email", "groups", "offline_access"}
-
 func isStandardScope(scope string) bool {
-	return slices.Contains(standardScopes, scope)
+	// standardScopes are the built-in identity scopes that any client may request
+	switch scope {
+	case "openid", "profile", "email", "groups", "offline_access":
+		return true
+	default:
+		return false
+	}
 }
 
 // PermissionInfo is the display information for an API permission used to show friendly names and descriptions on the consent screen
@@ -50,12 +52,19 @@ type APIAccessProvider interface {
 // An empty resource is a plain login token bound to the requesting client and yields only identity scopes
 // The subject type selects which of the client's grants apply: user-delegated flows only see user grants, the client credentials grant only sees client grants
 func resolveResource(ctx context.Context, provider APIAccessProvider, clientID, resource string, requestedScopes []string, subjectType SubjectType) (audience string, grantedScopes []string, err error) {
-	var grantable []string
+	// Include the standard scopes by default
+	// These are released as ID-token and userinfo claims and are always available without targeting an API
+	grantable := map[string]struct{}{
+		"openid":         {},
+		"profile":        {},
+		"email":          {},
+		"groups":         {},
+		"offline_access": {},
+	}
 
 	if resource == "" {
 		// A plain login token is audienced to the requesting client and carries only identity scopes
 		audience = clientID
-		grantable = standardScopes
 	} else {
 		if provider == nil {
 			return "", nil, fosite.ErrInvalidRequest.WithHintf("The resource %q is not a known API.", resource)
@@ -78,28 +87,26 @@ func resolveResource(ctx context.Context, provider APIAccessProvider, clientID, 
 		audience = resource
 		// Identity scopes stay grantable alongside a custom API so the ID token and its claims still work when openid or profile are requested
 		// Custom scopes are limited to what the client is allowed for this specific API
-		grantable = append(append([]string{}, standardScopes...), allowed...)
+		for _, a := range allowed {
+			grantable[a] = struct{}{}
+		}
 	}
 
 	// Every requested scope must belong to the targeted API, though identity scopes are always allowed
 	// A custom scope requested without its API, or for a different API than the one targeted, is rejected rather than silently dropped
+	granted := make([]string, 0, len(requestedScopes))
 	for _, scope := range requestedScopes {
-		if !slices.Contains(grantable, scope) {
+		_, ok := grantable[scope]
+		if !ok {
 			return "", nil, fosite.ErrInvalidScope.WithHintf("The scope %q is not available for the requested resource.", scope)
 		}
-	}
 
-	return audience, intersectScopes(requestedScopes, grantable), nil
-}
-
-func intersectScopes(requested, allowed []string) []string {
-	result := make([]string, 0, len(requested))
-	for _, scope := range requested {
-		if slices.Contains(allowed, scope) && !slices.Contains(result, scope) {
-			result = append(result, scope)
+		if !slices.Contains(granted, scope) {
+			granted = append(granted, scope)
 		}
 	}
-	return result
+
+	return audience, granted, nil
 }
 
 // consentScopeKey qualifies a custom-API scope by its audience so the same permission key on two different APIs is consented to separately

--- a/backend/internal/oidc/api_resource_test.go
+++ b/backend/internal/oidc/api_resource_test.go
@@ -2,6 +2,7 @@ package oidc
 
 import (
 	"context"
+	"net/url"
 	"slices"
 	"testing"
 
@@ -160,6 +161,22 @@ func TestResolveResourceClientWithoutClientGrantsIsDenied(t *testing.T) {
 
 	_, _, err := resolveResource(t.Context(), provider, "client-1", "https://api.orders.example.com", nil, SubjectTypeClient)
 	require.Error(t, err)
+}
+
+func TestResourceFromForm(t *testing.T) {
+	// No resource yields an empty value with no error
+	resource, err := resourceFromForm(url.Values{})
+	require.NoError(t, err)
+	assert.Empty(t, resource)
+
+	// A single resource is returned as-is
+	resource, err = resourceFromForm(url.Values{"resource": {"https://api.orders.example.com"}})
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.orders.example.com", resource)
+
+	// More than one resource is rejected rather than silently narrowed to the first
+	_, err = resourceFromForm(url.Values{"resource": {"https://api.orders.example.com", "https://api.billing.example.com"}})
+	require.ErrorIs(t, err, errMultipleResources)
 }
 
 func TestConsentScopeKeyQualifiesCustomScopesOnly(t *testing.T) {

--- a/backend/internal/oidc/authorization_service.go
+++ b/backend/internal/oidc/authorization_service.go
@@ -529,17 +529,22 @@ func (s *authorizationService) buildInteractionForUser(ctx context.Context, inte
 // resolveScopeInfo resolves display names and descriptions for the requested non-standard scopes, looked up against the API targeted by the request's RFC 8707 resource
 // Standard identity scopes are rendered by the client
 func (s *authorizationService) resolveScopeInfo(ctx context.Context, interactionSession InteractionSession) ([]scopeInfoDto, error) {
+	return s.resolveScopeInfoForRequest(ctx, interactionSession.Parameters["resource"], interactionSession.Scopes)
+}
+
+// resolveScopeInfoForRequest resolves display names and descriptions for the requested non-standard scopes against the API identified by resource
+// The browser and device consent flows share it so both show friendly permission names instead of raw scope keys
+func (s *authorizationService) resolveScopeInfoForRequest(ctx context.Context, resource string, scopes []string) ([]scopeInfoDto, error) {
 	if s.apiAccess == nil {
 		return nil, nil
 	}
 
-	resource := interactionSession.Parameters["resource"]
 	if resource == "" {
 		return nil, nil
 	}
 
-	var customKeys []string
-	for _, scope := range interactionSession.Scopes {
+	customKeys := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
 		if !isStandardScope(scope) {
 			customKeys = append(customKeys, scope)
 		}

--- a/backend/internal/oidc/authorization_service.go
+++ b/backend/internal/oidc/authorization_service.go
@@ -121,9 +121,14 @@ func (s *authorizationService) authorize(ctx context.Context, input authorizeInp
 		return authorizationResult{}, &common.OidcPARRequiredError{}
 	}
 
+	// Only a single RFC 8707 resource is supported, so reject a request that carries more than one rather than silently honoring the first
+	resource, err := resourceFromForm(input.requester.GetRequestForm())
+	if err != nil {
+		return authorizationResult{}, err
+	}
+
 	// Validate the requested scopes against the targeted API up front, before the user authenticates or reaches the consent screen
 	// This rejects a custom permission requested without, or with the wrong, resource at the authorize endpoint itself
-	resource := input.requester.GetRequestForm().Get("resource")
 	_, _, _, err = s.resolveGrant(ctx, client.GetID(), resource, input.requester.GetRequestedScopes())
 	if err != nil {
 		// resolveGrant distinguishes an unknown API, an API this client is not granted, and a scope not allowed for the API

--- a/backend/internal/oidc/authorization_service.go
+++ b/backend/internal/oidc/authorization_service.go
@@ -3,6 +3,7 @@ package oidc
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/url"
 	"slices"
 	"strconv"
@@ -105,7 +106,8 @@ func (s *authorizationService) authorize(ctx context.Context, input authorizeInp
 	client := input.requester.GetClient().(Client)
 	prompt := newPromptValues(input.requester.GetRequestForm().Get("prompt"))
 
-	if err := validateClientPKCERequirement(client, input.requester); err != nil {
+	err := validateClientPKCERequirement(client, input.requester)
+	if err != nil {
 		return authorizationResult{}, err
 	}
 
@@ -114,7 +116,7 @@ func (s *authorizationService) authorize(ctx context.Context, input authorizeInp
 		return authorizationResult{}, err
 	}
 
-	// Reject authorization requests that require PAR when the request is not a resumed interaction and doesn't have a valid PAR.
+	// Reject authorization requests that require PAR when the request is not a resumed interaction and doesn't have a valid PAR
 	if client.RequiresPushedAuthorizationRequests && !input.hasPushedAuthorizationRequest && interactionSession == nil {
 		return authorizationResult{}, &common.OidcPARRequiredError{}
 	}
@@ -122,7 +124,17 @@ func (s *authorizationService) authorize(ctx context.Context, input authorizeInp
 	// Validate the requested scopes against the targeted API up front, before the user authenticates or reaches the consent screen
 	// This rejects a custom permission requested without, or with the wrong, resource at the authorize endpoint itself
 	resource := input.requester.GetRequestForm().Get("resource")
-	if _, _, _, err := s.resolveGrant(ctx, client.GetID(), resource, input.requester.GetRequestedScopes()); err != nil {
+	_, _, _, err = s.resolveGrant(ctx, client.GetID(), resource, input.requester.GetRequestedScopes())
+	if err != nil {
+		// resolveGrant distinguishes an unknown API, an API this client is not granted, and a scope not allowed for the API
+		// This validation runs before authentication, so returning those distinct errors would let anyone holding a public client_id diff the responses to enumerate which API audiences exist and which ones the client may request
+		// Collapse every resource-targeted failure into one generic invalid_request so the pre-auth response reveals no backend state, while keeping the underlying reason in the server log for operators
+		// A request that names no resource cannot leak API topology, so its scope error is returned unchanged to help legitimate integrations
+		if resource != "" {
+			slog.DebugContext(ctx, "Rejected authorize request with an invalid or unauthorized resource or scope", "client_id", client.GetID(), "error", err.Error())
+			return authorizationResult{}, fosite.ErrInvalidRequest.WithHint("The 'resource' or 'scope' parameter is invalid.")
+		}
+
 		return authorizationResult{}, err
 	}
 
@@ -156,24 +168,19 @@ func (s *authorizationService) authorize(ctx context.Context, input authorizeInp
 
 	var result authorizationResult
 	err = withTx(ctx, s.db, func(ctx context.Context) error {
-		var err error
-		result, err = s.authorizeAuthenticated(ctx, req)
-		if err != nil {
-			return err
+		var txErr error
+		result, txErr = s.authorizeAuthenticated(ctx, req)
+		if txErr != nil {
+			return txErr
 		}
 
-		if codeChallenge != "" &&
-			!client.PkceEnabled &&
-			!client.PkceSupported {
-
+		if codeChallenge != "" && !client.PkceEnabled && !client.PkceSupported {
 			tx := dbFromContext(ctx, s.db)
-
 			_ = flagPkceSupportedClient(ctx, client.GetID(), tx)
 		}
 
 		return nil
 	})
-
 	if err != nil {
 		return authorizationResult{}, err
 	}
@@ -182,7 +189,8 @@ func (s *authorizationService) authorize(ctx context.Context, input authorizeInp
 		return result, nil
 	}
 
-	if err := s.claimsService.applyIDTokenClaims(ctx, result.Session, input.requester.GetGrantedScopes()); err != nil {
+	err = s.claimsService.applyIDTokenClaims(ctx, result.Session, input.requester.GetGrantedScopes())
+	if err != nil {
 		return authorizationResult{}, err
 	}
 

--- a/backend/internal/oidc/authorization_service_test.go
+++ b/backend/internal/oidc/authorization_service_test.go
@@ -92,6 +92,50 @@ func TestAuthorizationServiceRejectsCustomScopeWithoutResource(t *testing.T) {
 	require.Equal(t, "invalid_scope", rfcErr.ErrorField)
 }
 
+// TestAuthorizationServiceCollapsesResourceErrorsBeforeAuthentication guards the pre-authentication resource validation against API enumeration.
+// An unknown API and an API the client is simply not granted are different backend states, but the authorize endpoint runs before the user logs in, so both must surface the exact same generic error; otherwise anyone holding a public client_id could diff the responses to map which API audiences exist and which ones the client may request.
+func TestAuthorizationServiceCollapsesResourceErrorsBeforeAuthentication(t *testing.T) {
+	const (
+		clientID   = "test-client"
+		knownAPI   = "https://api.orders.example.com"
+		unknownAPI = "https://api.unknown.example.com"
+	)
+
+	authorizeWithResource := func(t *testing.T, apiAccess APIAccessProvider, resource string) error {
+		t.Helper()
+		db := testutils.NewDatabaseForTest(t)
+		require.NoError(t, db.Create(&model.OidcClient{Base: model.Base{ID: clientID}, Name: "Test Client"}).Error)
+		service := newAuthorizationService(db, newInteractionSessionService(db), newClaimsService(db, nil, "", nil), nil, nil, apiAccess)
+
+		requester := newTestAuthorizeRequesterWithForm("resource-probe", clientID, url.Values{"resource": {resource}})
+		_, err := service.authorize(t.Context(), authorizeInput{
+			userID:             "test-user",
+			authenticationTime: time.Now().UTC(),
+			requester:          requester,
+		})
+		return err
+	}
+
+	// The targeted API does not exist at all
+	unknownErr := authorizeWithResource(t, fakeAPIAccess{allowed: map[string][]string{}}, unknownAPI)
+	// The targeted API exists but this client has been granted none of its permissions
+	ungrantedErr := authorizeWithResource(t, fakeAPIAccess{allowed: map[string][]string{knownAPI: {}}}, knownAPI)
+
+	require.Error(t, unknownErr)
+	require.Error(t, ungrantedErr)
+
+	var unknownRFC, ungrantedRFC *fosite.RFC6749Error
+	require.ErrorAs(t, unknownErr, &unknownRFC)
+	require.ErrorAs(t, ungrantedErr, &ungrantedRFC)
+
+	// Both states collapse to the identical generic error, so an anonymous caller cannot tell an unknown API from an ungranted one
+	require.Equal(t, "invalid_request", unknownRFC.ErrorField)
+	require.Equal(t, unknownRFC.ErrorField, ungrantedRFC.ErrorField)
+	require.Equal(t, unknownRFC.GetDescription(), ungrantedRFC.GetDescription())
+	// The ungranted case must not leak fosite's access_denied, which would reveal that the API exists
+	require.NotEqual(t, "access_denied", ungrantedRFC.ErrorField)
+}
+
 func TestAuthorizationServiceConsentStepLogsNewClientAuthorization(t *testing.T) {
 	db := testutils.NewDatabaseForTest(t)
 	auditLogger := &fakeAuditLogger{}

--- a/backend/internal/oidc/authorization_service_test.go
+++ b/backend/internal/oidc/authorization_service_test.go
@@ -117,9 +117,9 @@ func TestAuthorizationServiceCollapsesResourceErrorsBeforeAuthentication(t *test
 	}
 
 	// The targeted API does not exist at all
-	unknownErr := authorizeWithResource(t, fakeAPIAccess{allowed: map[string][]string{}}, unknownAPI)
+	unknownErr := authorizeWithResource(t, userAccess(map[string][]string{}), unknownAPI)
 	// The targeted API exists but this client has been granted none of its permissions
-	ungrantedErr := authorizeWithResource(t, fakeAPIAccess{allowed: map[string][]string{knownAPI: {}}}, knownAPI)
+	ungrantedErr := authorizeWithResource(t, userAccess(map[string][]string{knownAPI: {}}), knownAPI)
 
 	require.Error(t, unknownErr)
 	require.Error(t, ungrantedErr)

--- a/backend/internal/oidc/client.go
+++ b/backend/internal/oidc/client.go
@@ -5,9 +5,6 @@ import (
 	"github.com/pocket-id/pocket-id/backend/internal/model"
 )
 
-var _ fosite.Client = (*Client)(nil)
-var _ fosite.ResponseModeClient = (*Client)(nil)
-
 type Client struct {
 	model.OidcClient
 
@@ -44,8 +41,12 @@ func (c Client) GetResponseTypes() fosite.Arguments {
 }
 
 func (c Client) GetScopes() fosite.Arguments {
-	scopes := make(fosite.Arguments, 0, len(standardScopes)+len(c.apiScopes))
-	scopes = append(scopes, standardScopes...)
+	scopes := make(fosite.Arguments, 5, 5+len(c.apiScopes))
+	scopes[0] = "openid"
+	scopes[1] = "profile"
+	scopes[2] = "email"
+	scopes[3] = "groups"
+	scopes[4] = "offline_access"
 	scopes = append(scopes, c.apiScopes...)
 	return scopes
 }

--- a/backend/internal/oidc/client_test.go
+++ b/backend/internal/oidc/client_test.go
@@ -1,0 +1,11 @@
+package oidc
+
+import (
+	"github.com/ory/fosite"
+)
+
+// Interface assertions
+var (
+	_ fosite.Client             = (*Client)(nil)
+	_ fosite.ResponseModeClient = (*Client)(nil)
+)

--- a/backend/internal/oidc/device_service.go
+++ b/backend/internal/oidc/device_service.go
@@ -154,9 +154,9 @@ func (s *deviceService) getDeviceCodeInfo(ctx context.Context, userCode, userID 
 	}
 
 	client := request.GetClient().(Client)
+	resource := request.GetRequestForm().Get("resource")
 	authorizationRequired := true
 	if userID != "" {
-		resource := request.GetRequestForm().Get("resource")
 		_, _, consentKeys, err := s.authorizationService.resolveGrant(ctx, client.GetID(), resource, request.GetRequestedScopes())
 		if err != nil {
 			return nil, err
@@ -169,6 +169,21 @@ func (s *deviceService) getDeviceCodeInfo(ctx context.Context, userCode, userID 
 		authorizationRequired = consentRequired(hasAuthorizedClient, client.SkipConsent, nil)
 	}
 
+	// Resolve friendly names for the requested custom-API permissions so the device consent screen matches the browser flow
+	scopeInfo, err := s.authorizationService.resolveScopeInfoForRequest(ctx, resource, request.GetRequestedScopes())
+	if err != nil {
+		return nil, err
+	}
+	// Always serialize a possibly empty array rather than null
+	scopeInfoDtos := make([]dto.ScopeInfoDto, len(scopeInfo))
+	for i, info := range scopeInfo {
+		scopeInfoDtos[i] = dto.ScopeInfoDto{
+			Key:         info.Key,
+			Name:        info.Name,
+			Description: info.Description,
+		}
+	}
+
 	return &dto.DeviceCodeInfoDto{
 		Client: dto.OidcClientMetaDataDto{
 			ID:                       client.ID,
@@ -179,6 +194,7 @@ func (s *deviceService) getDeviceCodeInfo(ctx context.Context, userCode, userID 
 			RequiresReauthentication: client.RequiresReauthentication,
 		},
 		Scope:                    request.GetRequestedScopes(),
+		ScopeInfo:                scopeInfoDtos,
 		AuthorizationRequired:    authorizationRequired,
 		ReauthenticationRequired: client.RequiresReauthentication,
 	}, nil

--- a/backend/internal/oidc/device_service.go
+++ b/backend/internal/oidc/device_service.go
@@ -50,6 +50,12 @@ func (s *deviceService) createDeviceAuthorization(ctx context.Context, req *http
 		return nil, request, err
 	}
 
+	// Only a single RFC 8707 resource is supported, so reject a device authorization that carries more than one before a user code is minted
+	_, err = resourceFromForm(request.GetRequestForm())
+	if err != nil {
+		return nil, request, err
+	}
+
 	session := NewEmptySession()
 	response, err := s.provider.NewDeviceResponse(ctx, request, session)
 	if err != nil {

--- a/backend/internal/oidc/device_service_test.go
+++ b/backend/internal/oidc/device_service_test.go
@@ -2,8 +2,9 @@ package oidc
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -96,7 +97,7 @@ func newTestDeviceServiceWithCode(t *testing.T, clientID, userID string, require
 	}).Error)
 
 	store := NewStore(db, nil)
-	signerKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	signerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	provider, err := newProvider(store, nil, testTokenSigner{key: signerKey}, Config{ //nolint:gosec // static test-only provider secret
 		BaseURL:      "https://issuer.example.com",

--- a/backend/internal/oidc/end_session_service_test.go
+++ b/backend/internal/oidc/end_session_service_test.go
@@ -1,6 +1,8 @@
 package oidc
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"net/url"
@@ -83,7 +85,7 @@ func TestEndSessionService(t *testing.T) {
 		jti      = "id-token-jti"
 	)
 
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	signer := testTokenSigner{key: key}
 
@@ -117,7 +119,7 @@ func TestEndSessionService(t *testing.T) {
 		}
 		token, err := builder.Build()
 		require.NoError(t, err)
-		signed, err := jwt.Sign(token, jwt.WithKey(jwa.RS256(), key))
+		signed, err := jwt.Sign(token, jwt.WithKey(jwa.ES256(), key))
 		require.NoError(t, err)
 		return string(signed)
 	}

--- a/backend/internal/oidc/introspection_handler_test.go
+++ b/backend/internal/oidc/introspection_handler_test.go
@@ -1,8 +1,9 @@
 package oidc
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -34,7 +35,7 @@ func TestIntrospectionHandlerBindsTokenToCallerClient(t *testing.T) {
 	require.NoError(t, db.Create(&model.OidcClient{Base: model.Base{ID: "client-a"}, Name: "Client A"}).Error)
 	require.NoError(t, db.Create(&model.OidcClient{Base: model.Base{ID: "client-b"}, Name: "Client B"}).Error)
 
-	signerKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	signerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
 	provider, err := newProvider(NewStore(db, nil), nil, testTokenSigner{key: signerKey}, Config{ //nolint:gosec // static test-only provider secret
@@ -139,7 +140,7 @@ func TestIntrospectionHandlerAllowsReusedFederatedClientAssertion(t *testing.T) 
 	authenticator, err := newFederatedClientAuthenticator(t.Context(), store, newJWKSetHTTPClient(t, jwks), baseURL)
 	require.NoError(t, err)
 
-	signerKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	signerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	provider, err := newProvider(store, authenticator, testTokenSigner{key: signerKey}, Config{ //nolint:gosec // static test-only provider secret
 		BaseURL:      baseURL,

--- a/backend/internal/oidc/module.go
+++ b/backend/internal/oidc/module.go
@@ -64,7 +64,7 @@ type Module struct {
 }
 
 func New(ctx context.Context, deps Dependencies) (*Module, error) {
-	store := NewStore(deps.DB, deps.APIAccess)
+	store := NewStore(deps.DB, deps.APIAccess).WithIssuer(deps.Config.BaseURL)
 	authenticator, err := newFederatedClientAuthenticator(ctx, store, deps.HTTPClient, deps.Config.BaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create federated client authenticator: %w", err)
@@ -89,7 +89,7 @@ func New(ctx context.Context, deps Dependencies) (*Module, error) {
 
 		authorizationHandler: newAuthorizationHandler(provider, authorizationService, deps.Config.BaseURL),
 		tokenHandler:         newTokenHandler(provider, claimsService, deps.APIAccess),
-		userInfoHandler:      newUserInfoHandler(provider, claimsService),
+		userInfoHandler:      newUserInfoHandler(provider, claimsService, deps.Config.BaseURL),
 		parHandler:           newPARHandler(provider),
 		introspectionHandler: newIntrospectionHandler(provider, authenticator, deps.Config.BaseURL),
 		endSessionHandler:    newEndSessionHandler(endSessionService, deps.Config.BaseURL),

--- a/backend/internal/oidc/preview_test.go
+++ b/backend/internal/oidc/preview_test.go
@@ -1,8 +1,9 @@
 package oidc
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,7 +14,7 @@ import (
 
 func TestClientPreviewBuilderUsesFositeTokenStrategies(t *testing.T) {
 	db := testutils.NewDatabaseForTest(t)
-	signerKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	signerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
 	provider, err := newProvider(NewStore(db, nil), nil, testTokenSigner{key: signerKey}, Config{ //nolint:gosec // static test-only provider secret
@@ -60,7 +61,7 @@ func TestClientPreviewBuilderUsesFositeTokenStrategies(t *testing.T) {
 
 func TestClientPreviewBuilderRejectsInvalidScope(t *testing.T) {
 	db := testutils.NewDatabaseForTest(t)
-	signerKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	signerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
 	provider, err := newProvider(NewStore(db, nil), nil, testTokenSigner{key: signerKey}, Config{ //nolint:gosec // static test-only provider secret

--- a/backend/internal/oidc/preview_test.go
+++ b/backend/internal/oidc/preview_test.go
@@ -46,7 +46,8 @@ func TestClientPreviewBuilderUsesFositeTokenStrategies(t *testing.T) {
 
 	require.Equal(t, "https://issuer.example.com", preview.AccessToken["iss"])
 	require.ElementsMatch(t, []string{"openid", "email"}, stringSliceClaim(t, preview.AccessToken["scp"]))
-	require.ElementsMatch(t, []string{clientID}, stringSliceClaim(t, preview.AccessToken["aud"]))
+	// The identity scopes add the issuer to the audience so the previewed token would also work at /userinfo
+	require.ElementsMatch(t, []string{clientID, "https://issuer.example.com"}, stringSliceClaim(t, preview.AccessToken["aud"]))
 	require.NotContains(t, preview.AccessToken, "type")
 
 	require.Equal(t, userID, preview.IDToken["sub"])

--- a/backend/internal/oidc/provider.go
+++ b/backend/internal/oidc/provider.go
@@ -67,6 +67,9 @@ func newProvider(store *Store, authenticator *federatedClientAuthenticator, sign
 		HMACSHAStrategy: coreStrategy,
 		Config:          fositeConfig,
 	}
+	// Wrap the access token strategy so an access token audienced to a custom API never carries identity scopes on the token itself
+	// The ID token still receives them from the untouched grant.
+	apiAccessTokenStrategy := apiAudienceAccessTokenStrategy{CoreStrategy: accessTokenStrategy}
 	idTokenStrategy := &openid.DefaultStrategy{
 		Signer: sig,
 		Config: fositeConfig,
@@ -75,7 +78,7 @@ func newProvider(store *Store, authenticator *federatedClientAuthenticator, sign
 		fositeConfig,
 		store,
 		&compose.CommonStrategy{
-			CoreStrategy:               accessTokenStrategy,
+			CoreStrategy:               apiAccessTokenStrategy,
 			RFC8628CodeStrategy:        deviceStrategy,
 			OpenIDConnectTokenStrategy: idTokenStrategy,
 			Signer:                     sig,
@@ -98,7 +101,7 @@ func newProvider(store *Store, authenticator *federatedClientAuthenticator, sign
 		OAuth2Provider: provider,
 		deviceStrategy: deviceStrategy,
 		tokenStrategies: tokenStrategies{
-			accessToken: accessTokenStrategy,
+			accessToken: apiAccessTokenStrategy,
 			idToken:     idTokenStrategy,
 			config:      fositeConfig,
 		},

--- a/backend/internal/oidc/provider.go
+++ b/backend/internal/oidc/provider.go
@@ -67,9 +67,10 @@ func newProvider(store *Store, authenticator *federatedClientAuthenticator, sign
 		HMACSHAStrategy: coreStrategy,
 		Config:          fositeConfig,
 	}
-	// Wrap the access token strategy so an access token audienced to a custom API never carries identity scopes on the token itself
-	// The ID token still receives them from the untouched grant.
-	apiAccessTokenStrategy := apiAudienceAccessTokenStrategy{CoreStrategy: accessTokenStrategy}
+
+	// Wrap the access token strategy so an access token granted an identity scope also lists the issuer in its audience
+	// This lets it be presented to Pocket ID's own identity endpoints such as /userinfo, while a token audienced only to a custom API is not accepted there
+	apiAccessTokenStrategy := identityAudienceAccessTokenStrategy{CoreStrategy: accessTokenStrategy, issuer: config.BaseURL}
 	idTokenStrategy := &openid.DefaultStrategy{
 		Signer: sig,
 		Config: fositeConfig,

--- a/backend/internal/oidc/provider_test.go
+++ b/backend/internal/oidc/provider_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 type testTokenSigner struct {
-	key *rsa.PrivateKey
+	key *ecdsa.PrivateKey
 }
 
 func (s testTokenSigner) GetPrivateKey() any {
@@ -31,7 +31,7 @@ func (s testTokenSigner) GetPrivateKey() any {
 }
 
 func (s testTokenSigner) GetKeyAlg() (jwa.KeyAlgorithm, error) {
-	return jwa.RS256(), nil
+	return jwa.ES256(), nil
 }
 
 func (s testTokenSigner) GetKeyID() (string, bool) {
@@ -52,7 +52,7 @@ func TestDeriveGlobalSecretUsesStableValue(t *testing.T) {
 
 func TestProviderIssuesJWTAccessTokens(t *testing.T) {
 	db := testutils.NewDatabaseForTest(t)
-	signerKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	signerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
 	provider, err := newProvider(NewStore(db, nil), nil, testTokenSigner{key: signerKey}, Config{ //nolint:gosec // static test-only provider secret
@@ -87,7 +87,7 @@ func TestProviderIssuesJWTAccessTokens(t *testing.T) {
 
 func TestProviderAcceptsWildcardRedirectURI(t *testing.T) {
 	db := testutils.NewDatabaseForTest(t)
-	signerKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	signerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	require.NoError(t, db.Create(&model.OidcClient{
 		Base:         model.Base{ID: "test-client"},
@@ -119,7 +119,7 @@ func TestProviderAcceptsWildcardRedirectURI(t *testing.T) {
 
 func TestProviderAcceptsPushedAuthorizationWildcardRedirectURI(t *testing.T) {
 	db := testutils.NewDatabaseForTest(t)
-	signerKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	signerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	require.NoError(t, db.Create(&model.OidcClient{
 		Base:         model.Base{ID: "test-client"},
@@ -152,7 +152,7 @@ func TestProviderAcceptsPushedAuthorizationWildcardRedirectURI(t *testing.T) {
 
 func TestProviderRejectsUnmatchedWildcardRedirectURI(t *testing.T) {
 	db := testutils.NewDatabaseForTest(t)
-	signerKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	signerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	require.NoError(t, db.Create(&model.OidcClient{
 		Base:         model.Base{ID: "test-client"},

--- a/backend/internal/oidc/store.go
+++ b/backend/internal/oidc/store.go
@@ -50,6 +50,14 @@ func NewStore(db *gorm.DB, apiAccess APIAccessProvider) *Store {
 type Store struct {
 	db        *gorm.DB
 	apiAccess APIAccessProvider
+	issuer    string
+}
+
+// WithIssuer sets the issuer that is added as an extra audience to access tokens carrying an identity scope, so they can be presented to Pocket ID's own endpoints such as /userinfo
+// It returns the store to allow chaining at construction
+func (s *Store) WithIssuer(issuer string) *Store {
+	s.issuer = issuer
+	return s
 }
 
 type storedRequester struct {
@@ -156,8 +164,9 @@ func (s *Store) InvalidateAuthorizeCodeSession(ctx context.Context, code string)
 }
 
 func (s *Store) CreateAccessTokenSession(ctx context.Context, signature string, request fosite.Requester) error {
-	// userinfo and introspection read the granted scopes from the persisted access token session, so an access token audienced to a custom API must be stored without identity scopes to keep it from being replayed as an identity token. The ID token is issued from the untouched live request.
-	return s.upsertSession(ctx, sessionKindAccessToken, signature, withAccessTokenScopes(request), "", true, fosite.AccessToken)
+	// userinfo and introspection read the granted audience from the persisted access token session, so an access token granted an identity scope is stored with the issuer added to its audience, letting it be presented to Pocket ID's own identity endpoints
+	// A token audienced only to a custom API carries no identity scope here and so never gains the issuer audience
+	return s.upsertSession(ctx, sessionKindAccessToken, signature, withIdentityAudience(request, s.issuer), "", true, fosite.AccessToken)
 }
 
 func (s *Store) GetAccessTokenSession(ctx context.Context, signature string, _ fosite.Session) (fosite.Requester, error) {

--- a/backend/internal/oidc/store.go
+++ b/backend/internal/oidc/store.go
@@ -78,39 +78,30 @@ type storedRequester struct {
 // Satisfies fosite.Storage
 
 func (s *Store) GetClient(ctx context.Context, id string) (fosite.Client, error) {
-	var client Client
-	err := withTx(ctx, s.db, func(ctx context.Context) error {
-		// withTx guarantees a transaction in the context, so dbFor resolves to it
-		tx := s.dbFor(ctx)
+	tx := s.dbFor(ctx)
 
-		var clientModel model.OidcClient
-		err := tx.
-			Preload("AllowedUserGroups").
-			First(&clientModel, "id = ?", id).
-			Error
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return fosite.ErrNotFound
-		}
-		if err != nil {
-			return err
-		}
-
-		client = Client{OidcClient: clientModel}
-
-		// Populate the API scopes and audiences for the client if the API access provider is available
-		if s.apiAccess != nil {
-			apiScopes, apiAudiences, err := s.apiAccess.ClientAPIScopes(ctx, tx, id)
-			if err != nil {
-				return err
-			}
-			client.apiScopes = apiScopes
-			client.apiAudiences = apiAudiences
-		}
-
-		return nil
-	})
-	if err != nil {
+	var clientModel model.OidcClient
+	err := tx.
+		Preload("AllowedUserGroups").
+		First(&clientModel, "id = ?", id).
+		Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fosite.ErrNotFound
+	} else if err != nil {
 		return nil, err
+	}
+
+	client := Client{OidcClient: clientModel}
+
+	// Populate the custom-API scopes and audiences the client may request only when the API feature is wired
+	if s.apiAccess != nil {
+		apiScopes, apiAudiences, err := s.apiAccess.ClientAPIScopes(ctx, tx, id)
+		if err != nil {
+			return nil, err
+		}
+
+		client.apiScopes = apiScopes
+		client.apiAudiences = apiAudiences
 	}
 
 	return client, nil

--- a/backend/internal/oidc/store.go
+++ b/backend/internal/oidc/store.go
@@ -165,7 +165,8 @@ func (s *Store) InvalidateAuthorizeCodeSession(ctx context.Context, code string)
 }
 
 func (s *Store) CreateAccessTokenSession(ctx context.Context, signature string, request fosite.Requester) error {
-	return s.upsertSession(ctx, sessionKindAccessToken, signature, request, "", true, fosite.AccessToken)
+	// userinfo and introspection read the granted scopes from the persisted access token session, so an access token audienced to a custom API must be stored without identity scopes to keep it from being replayed as an identity token. The ID token is issued from the untouched live request.
+	return s.upsertSession(ctx, sessionKindAccessToken, signature, withAccessTokenScopes(request), "", true, fosite.AccessToken)
 }
 
 func (s *Store) GetAccessTokenSession(ctx context.Context, signature string, _ fosite.Session) (fosite.Requester, error) {

--- a/backend/internal/oidc/token_handler.go
+++ b/backend/internal/oidc/token_handler.go
@@ -45,7 +45,8 @@ func (h *tokenHandler) token(c *gin.Context) {
 
 	if client, ok := accessRequest.GetClient().(Client); ok {
 		// Re-validate the resource owner on every user-bound grant.
-		if err := h.claimsService.ValidateUserAccess(ctx, requestSession.Subject, client); err != nil {
+		err := h.claimsService.ValidateUserAccess(ctx, requestSession.Subject, client)
+		if err != nil {
 			slog.WarnContext(ctx, "Rejected token request: user no longer allowed to access client", "error", err.Error())
 			h.provider.WriteAccessError(ctx, c.Writer, accessRequest, err)
 			return
@@ -55,7 +56,12 @@ func (h *tokenHandler) token(c *gin.Context) {
 		// It resolves against the client-subject grants: a permission delegated by users does not let the client act as itself
 		// The other grants had their audience and scope resolved at authorize or device time and restored from storage, so they must be left untouched
 		if accessRequest.GetGrantTypes().Has(string(fosite.GrantTypeClientCredentials)) {
-			resource := accessRequest.GetRequestForm().Get("resource")
+			// Only a single RFC 8707 resource is supported, so reject a request that carries more than one rather than silently honoring the first
+			resource, err := resourceFromForm(accessRequest.GetRequestForm())
+			if err != nil {
+				h.provider.WriteAccessError(ctx, c.Writer, accessRequest, err)
+				return
+			}
 			audience, grantedScopes, err := resolveResource(ctx, h.apiAccess, client.GetID(), resource, accessRequest.GetRequestedScopes(), SubjectTypeClient)
 			if err != nil {
 				h.provider.WriteAccessError(ctx, c.Writer, accessRequest, err)
@@ -64,7 +70,8 @@ func (h *tokenHandler) token(c *gin.Context) {
 			// A client credentials token has no resource owner, so it must never carry identity scopes such as openid or profile
 			// Dropping them keeps machine tokens out of the userinfo endpoint, which is gated on the openid scope
 			grantedScopes = slices.DeleteFunc(grantedScopes, isStandardScope)
-			if accessReq, ok := accessRequest.(*fosite.AccessRequest); ok {
+			accessReq, ok := accessRequest.(*fosite.AccessRequest)
+			if ok {
 				accessReq.GrantedScope = fosite.Arguments(grantedScopes)
 				accessReq.GrantedAudience = nil
 			}
@@ -72,7 +79,8 @@ func (h *tokenHandler) token(c *gin.Context) {
 		}
 	}
 
-	if err := h.claimsService.applyIDTokenClaims(ctx, requestSession, accessRequest.GetGrantedScopes()); err != nil {
+	err = h.claimsService.applyIDTokenClaims(ctx, requestSession, accessRequest.GetGrantedScopes())
+	if err != nil {
 		slog.ErrorContext(ctx, "Failed to apply ID token claims", "error", err)
 		h.provider.WriteAccessError(ctx, c.Writer, accessRequest, err)
 		return
@@ -81,7 +89,8 @@ func (h *tokenHandler) token(c *gin.Context) {
 	// The client credentials grant has no resource owner, so no subject is ever set. Assign a
 	// stable synthetic subject so the issued JWT access token still carries a subclaim.
 	if requestSession.Subject == "" {
-		if client, ok := accessRequest.GetClient().(Client); ok && accessRequest.GetGrantTypes().Has(string(fosite.GrantTypeClientCredentials)) {
+		client, ok := accessRequest.GetClient().(Client)
+		if ok && accessRequest.GetGrantTypes().Has(string(fosite.GrantTypeClientCredentials)) {
 			requestSession.Subject = "client-" + client.GetID()
 		}
 	}

--- a/backend/internal/oidc/token_handler_test.go
+++ b/backend/internal/oidc/token_handler_test.go
@@ -154,7 +154,7 @@ func TestTokenHandlerClientCredentialsUsesClientSubjectGrants(t *testing.T) {
 	)
 
 	db := testutils.NewDatabaseForTest(t)
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
 	hashed, err := bcrypt.GenerateFromPassword([]byte(clientPlain), bcrypt.DefaultCost)
@@ -202,14 +202,14 @@ func TestTokenHandlerClientCredentialsUsesClientSubjectGrants(t *testing.T) {
 		return body
 	}
 
-	// The client-subject grant is issued and audienced to the API.
-	body := requestToken(t, "write:orders")
+	// The client-subject grant is issued and audienced to the API
+	body := requestToken(t, "openid write:orders")
 	require.NotEmpty(t, body["access_token"], "client-granted scope must be issued, got error: %v (%v)", body["error"], body["error_description"])
 	claims := decodeJWTPart(t, body["access_token"].(string), 1)
-	require.Contains(t, jwtAudience(claims), apiAudience, "access token must be audience-bound to the API")
-	require.Contains(t, claims["scope"], "write:orders")
+	require.Equal(t, []string{apiAudience}, jwtAudience(claims), "access token must be audience-bound to the API")
+	require.Equal(t, []string{"write:orders"}, jwtScopes(claims), "identity scopes must be stripped from machine tokens")
 
-	// The permission users may delegate is not available to the client itself.
+	// The permission users may delegate is not available to the client itself
 	body = requestToken(t, "read:orders")
 	require.Empty(t, body["access_token"], "user-delegated permission must not be mintable machine-to-machine")
 	require.Equal(t, "invalid_scope", body["error"])

--- a/backend/internal/oidc/token_handler_test.go
+++ b/backend/internal/oidc/token_handler_test.go
@@ -1,12 +1,15 @@
 package oidc
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"encoding/json"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -42,7 +45,7 @@ func TestTokenHandlerClientCredentialsGrant(t *testing.T) {
 	)
 
 	db := testutils.NewDatabaseForTest(t)
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
 	hashed, err := bcrypt.GenerateFromPassword([]byte(clientPlain), bcrypt.DefaultCost)
@@ -96,7 +99,7 @@ func TestTokenHandlerClientCredentialsDropsIdentityScopes(t *testing.T) {
 	)
 
 	db := testutils.NewDatabaseForTest(t)
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
 	hashed, err := bcrypt.GenerateFromPassword([]byte(clientPlain), bcrypt.DefaultCost)
@@ -230,6 +233,32 @@ func jwtAudience(claims map[string]any) []string {
 	}
 }
 
+// jwtScopes extracts the scope claim from a decoded access token JWT as a sorted slice
+// It reads the RFC 9068 `scp` list claim and falls back to the space-delimited `scope` string
+func jwtScopes(claims map[string]any) []string {
+	var out []string
+	scp, ok := claims["scp"].([]any)
+	if ok {
+		for _, s := range scp {
+			str, ok := s.(string)
+			if ok {
+				out = append(out, str)
+			}
+		}
+	}
+
+	if out == nil {
+		scope, ok := claims["scope"].(string)
+		if ok && scope != "" {
+			out = strings.Fields(scope)
+		}
+	}
+
+	sort.Strings(out)
+
+	return out
+}
+
 // TestTokenHandlerRefreshGrantRevalidatesUser is the regression guard for the most
 // security-sensitive part of the fosite migration: fosite's refresh-token grant replays
 // the stored session without reloading the user, so the token handler must re-check the
@@ -246,7 +275,7 @@ func TestTokenHandlerRefreshGrantRevalidatesUser(t *testing.T) {
 		secret  = "test-secret"
 	)
 
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 	signer := testTokenSigner{key: key}
 
@@ -371,5 +400,162 @@ func TestTokenHandlerRefreshGrantRevalidatesUser(t *testing.T) {
 
 		require.Empty(t, body["access_token"])
 		require.Equal(t, "access_denied", body["error"])
+	})
+}
+
+func TestTokenHandlerRefreshGrantPreservesAudienceAndScope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const (
+		baseURL     = "https://issuer.example.com"
+		secret      = "test-secret"
+		apiResource = "https://api.orders.example.com"
+	)
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	signer := testTokenSigner{key: key}
+
+	// grantedAPI is a client that has been granted read:orders on the Orders API
+	grantedAPI := fakeAPIAccess{allowed: map[string][]string{apiResource: {"read:orders"}}}
+	// revokedAPI stands in for the same client after its API grant was removed: no APIs, no scopes
+	revokedAPI := fakeAPIAccess{allowed: map[string][]string{}}
+
+	// mintRefreshToken stores an active refresh-token session with the given granted scope and audience, standing in for a token issued by an earlier authorize, and returns the opaque token
+	mintRefreshToken := func(t *testing.T, db *gorm.DB, clientID, userID string, grantedScope, grantedAudience fosite.Arguments) string {
+		t.Helper()
+		globalSecret, err := DeriveGlobalSecret(secret)
+		require.NoError(t, err)
+		strategy := compose.NewOAuth2HMACStrategy(&fosite.Config{
+			GlobalSecret:         globalSecret,
+			RefreshTokenLifespan: 30 * 24 * time.Hour,
+		})
+		token, signature, err := strategy.GenerateRefreshToken(t.Context(), nil)
+		require.NoError(t, err)
+
+		now := time.Now().UTC()
+		session := NewEmptySession()
+		session.Subject = userID
+		session.Claims = &fositejwt.IDTokenClaims{
+			Subject:     userID,
+			RequestedAt: now,
+			AuthTime:    now,
+			Extra:       map[string]any{},
+		}
+		session.SetExpiresAt(fosite.RefreshToken, now.Add(30*24*time.Hour))
+		session.SetExpiresAt(fosite.AccessToken, now.Add(time.Hour))
+
+		request := fosite.NewRequest()
+		request.ID = "refresh-req-" + userID
+		request.RequestedAt = now
+		request.Client = Client{OidcClient: model.OidcClient{Base: model.Base{ID: clientID}, IsPublic: true}}
+		request.RequestedScope = grantedScope
+		request.GrantedScope = grantedScope
+		request.RequestedAudience = grantedAudience
+		request.GrantedAudience = grantedAudience
+		request.Session = session
+
+		err = NewStore(db, nil).CreateRefreshTokenSession(t.Context(), signature, "", request)
+		require.NoError(t, err)
+
+		return token
+	}
+
+	// doRefresh runs the refresh grant through the real HTTP handler; apiAccess widens the client's
+	// allowed scopes and audiences the same way the api module does in production, and extra merges
+	// additional form parameters (such as a widened scope) over the base refresh request
+	doRefresh := func(t *testing.T, db *gorm.DB, apiAccess APIAccessProvider, clientID, refreshToken string, extra url.Values) map[string]any {
+		t.Helper()
+		provider, err := newProvider(NewStore(db, apiAccess), nil, signer, Config{
+			BaseURL:      baseURL,
+			TokenBaseURL: baseURL,
+			Secret:       secret,
+		})
+		require.NoError(t, err)
+		handler := newTokenHandler(provider, newClaimsService(db, nil, baseURL, nil), nil)
+
+		form := url.Values{
+			"grant_type":    {"refresh_token"},
+			"refresh_token": {refreshToken},
+			"client_id":     {clientID},
+		}
+		maps.Copy(form, extra)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/oidc/token", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = req
+		handler.token(c)
+
+		var body map[string]any
+		err = json.Unmarshal(rec.Body.Bytes(), &body)
+		require.NoError(t, err)
+
+		return body
+	}
+
+	seedUserAndClient := func(t *testing.T, db *gorm.DB, clientID, userID string) {
+		t.Helper()
+		rErr := db.Create(&model.OidcClient{Base: model.Base{ID: clientID}, Name: "Client", IsPublic: true}).Error
+		require.NoError(t, rErr)
+		rErr = db.Create(&model.User{Base: model.Base{ID: userID}, Username: "tim"}).Error
+		require.NoError(t, rErr)
+	}
+
+	t.Run("refresh keeps the API audience and the access token carries only the API scope", func(t *testing.T) {
+		db := testutils.NewDatabaseForTest(t)
+		const clientID, userID = "client-api", "user-api"
+		seedUserAndClient(t, db, clientID, userID)
+
+		token := mintRefreshToken(t, db, clientID, userID,
+			fosite.Arguments{"openid", "read:orders"},
+			fosite.Arguments{apiResource},
+		)
+		body := doRefresh(t, db, grantedAPI, clientID, token, nil)
+		require.NotEmpty(t, body["access_token"], "expected a new access token, got error: %v", body["error"])
+		// The grant still carries openid, so the identity side keeps issuing an ID token on refresh
+		require.NotEmpty(t, body["id_token"])
+
+		claims := decodeJWTPart(t, body["access_token"].(string), 1)
+		// The refreshed access token stays bound to the original API audience and never widens it
+		require.Equal(t, []string{apiResource}, jwtAudience(claims))
+		// A token audienced to a custom API keeps only the API scope; identity scopes are stripped from the access token
+		require.Equal(t, []string{"read:orders"}, jwtScopes(claims))
+	})
+
+	t.Run("refresh cannot upscope beyond the original grant via the scope parameter", func(t *testing.T) {
+		db := testutils.NewDatabaseForTest(t)
+		const clientID, userID = "client-upscope", "user-upscope"
+		seedUserAndClient(t, db, clientID, userID)
+
+		token := mintRefreshToken(t, db, clientID, userID,
+			fosite.Arguments{"openid", "read:orders"},
+			fosite.Arguments{apiResource},
+		)
+		// The refresh handler ignores the scope parameter and replays the stored grant, so asking for write:orders is a no-op rather than an escalation
+		body := doRefresh(t, db, grantedAPI, clientID, token, url.Values{"scope": {"openid read:orders write:orders"}})
+		require.NotEmpty(t, body["access_token"], "expected a new access token, got error: %v", body["error"])
+
+		claims := decodeJWTPart(t, body["access_token"].(string), 1)
+		require.Equal(t, []string{apiResource}, jwtAudience(claims))
+		// write:orders never appears on the refreshed token even though it was requested
+		require.Equal(t, []string{"read:orders"}, jwtScopes(claims))
+	})
+
+	t.Run("revoking the client API grant makes the next refresh fail", func(t *testing.T) {
+		db := testutils.NewDatabaseForTest(t)
+		const clientID, userID = "client-revoked", "user-revoked"
+		seedUserAndClient(t, db, clientID, userID)
+
+		token := mintRefreshToken(t, db, clientID, userID,
+			fosite.Arguments{"openid", "read:orders"},
+			fosite.Arguments{apiResource},
+		)
+		// With the grant revoked the client no longer advertises read:orders, so the refresh handler rejects replaying that stored scope
+		// Revocation is therefore enforced on the very next refresh rather than lingering until the refresh token expires
+		body := doRefresh(t, db, revokedAPI, clientID, token, nil)
+		require.Empty(t, body["access_token"])
+		require.Equal(t, "invalid_scope", body["error"])
 	})
 }

--- a/backend/internal/oidc/token_handler_test.go
+++ b/backend/internal/oidc/token_handler_test.go
@@ -417,14 +417,14 @@ func TestTokenHandlerRefreshGrantPreservesAudienceAndScope(t *testing.T) {
 	signer := testTokenSigner{key: key}
 
 	// grantedAPI is a client that has been granted read:orders on the Orders API
-	grantedAPI := fakeAPIAccess{allowed: map[string][]string{apiResource: {"read:orders"}}}
+	grantedAPI := userAccess(map[string][]string{apiResource: {"read:orders"}})
 	// revokedAPI stands in for the same client after its API grant was removed: no APIs, no scopes
-	revokedAPI := fakeAPIAccess{allowed: map[string][]string{}}
+	revokedAPI := userAccess(map[string][]string{})
 
 	// mintRefreshToken stores an active refresh-token session with the given granted scope and audience, standing in for a token issued by an earlier authorize, and returns the opaque token
 	mintRefreshToken := func(t *testing.T, db *gorm.DB, clientID, userID string, grantedScope, grantedAudience fosite.Arguments) string {
 		t.Helper()
-		globalSecret, err := DeriveGlobalSecret(secret)
+		globalSecret, err := DeriveGlobalSecret([]byte(secret))
 		require.NoError(t, err)
 		strategy := compose.NewOAuth2HMACStrategy(&fosite.Config{
 			GlobalSecret:         globalSecret,
@@ -469,7 +469,7 @@ func TestTokenHandlerRefreshGrantPreservesAudienceAndScope(t *testing.T) {
 		provider, err := newProvider(NewStore(db, apiAccess), nil, signer, Config{
 			BaseURL:      baseURL,
 			TokenBaseURL: baseURL,
-			Secret:       secret,
+			Secret:       []byte(secret),
 		})
 		require.NoError(t, err)
 		handler := newTokenHandler(provider, newClaimsService(db, nil, baseURL, nil), nil)

--- a/backend/internal/oidc/token_handler_test.go
+++ b/backend/internal/oidc/token_handler_test.go
@@ -503,7 +503,7 @@ func TestTokenHandlerRefreshGrantPreservesAudienceAndScope(t *testing.T) {
 		require.NoError(t, rErr)
 	}
 
-	t.Run("refresh keeps the API audience and the access token carries only the API scope", func(t *testing.T) {
+	t.Run("refresh keeps the API audience and adds the issuer so the token still reaches userinfo", func(t *testing.T) {
 		db := testutils.NewDatabaseForTest(t)
 		const clientID, userID = "client-api", "user-api"
 		seedUserAndClient(t, db, clientID, userID)
@@ -518,10 +518,10 @@ func TestTokenHandlerRefreshGrantPreservesAudienceAndScope(t *testing.T) {
 		require.NotEmpty(t, body["id_token"])
 
 		claims := decodeJWTPart(t, body["access_token"].(string), 1)
-		// The refreshed access token stays bound to the original API audience and never widens it
-		require.Equal(t, []string{apiResource}, jwtAudience(claims))
-		// A token audienced to a custom API keeps only the API scope; identity scopes are stripped from the access token
-		require.Equal(t, []string{"read:orders"}, jwtScopes(claims))
+		// The refreshed access token stays bound to the original API audience and re-adds the issuer so it keeps working at userinfo, never widening to any other API
+		require.ElementsMatch(t, []string{apiResource, baseURL}, jwtAudience(claims))
+		// A token that requested openid alongside the API keeps the identity scope on the access token, matching what it was granted
+		require.Equal(t, []string{"openid", "read:orders"}, jwtScopes(claims))
 	})
 
 	t.Run("refresh cannot upscope beyond the original grant via the scope parameter", func(t *testing.T) {
@@ -538,9 +538,9 @@ func TestTokenHandlerRefreshGrantPreservesAudienceAndScope(t *testing.T) {
 		require.NotEmpty(t, body["access_token"], "expected a new access token, got error: %v", body["error"])
 
 		claims := decodeJWTPart(t, body["access_token"].(string), 1)
-		require.Equal(t, []string{apiResource}, jwtAudience(claims))
+		require.ElementsMatch(t, []string{apiResource, baseURL}, jwtAudience(claims))
 		// write:orders never appears on the refreshed token even though it was requested
-		require.Equal(t, []string{"read:orders"}, jwtScopes(claims))
+		require.Equal(t, []string{"openid", "read:orders"}, jwtScopes(claims))
 	})
 
 	t.Run("revoking the client API grant makes the next refresh fail", func(t *testing.T) {

--- a/backend/internal/oidc/tx.go
+++ b/backend/internal/oidc/tx.go
@@ -3,6 +3,7 @@ package oidc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"gorm.io/gorm"
@@ -19,32 +20,48 @@ func contextWithTx(ctx context.Context, tx *gorm.DB) context.Context {
 }
 
 func dbFromContext(ctx context.Context, fallback *gorm.DB) *gorm.DB {
-	if tx, ok := ctx.Value(txContextKey{}).(*gorm.DB); ok {
+	tx, ok := ctx.Value(txContextKey{}).(*gorm.DB)
+	if ok {
 		return tx.WithContext(ctx)
 	}
+
 	return fallback.WithContext(ctx)
 }
 
 // withTx runs fn inside a transaction, committing on nil error. Nested calls join the
 // outer transaction.
 func withTx(ctx context.Context, db *gorm.DB, fn func(ctx context.Context) error) error {
-	if _, ok := ctx.Value(txContextKey{}).(*gorm.DB); ok {
+	_, ok := ctx.Value(txContextKey{}).(*gorm.DB)
+	if ok {
 		return fn(ctx)
 	}
 
 	tx := db.WithContext(ctx).Begin()
 	if tx.Error != nil {
-		return tx.Error
+		return fmt.Errorf("error starting transaction: %w", tx.Error)
 	}
+
+	var committed bool
 	defer func() {
-		err := tx.Rollback().Error
-		if err != nil && !errors.Is(err, gorm.ErrInvalidTransaction) {
-			slog.ErrorContext(ctx, "Failed to rollback transaction", "error", err)
+		if committed {
+			return
+		}
+		rErr := tx.Rollback().Error
+		if rErr != nil && !errors.Is(rErr, gorm.ErrInvalidTransaction) {
+			slog.ErrorContext(ctx, "Failed to rollback transaction", "error", rErr)
 		}
 	}()
 
-	if err := fn(contextWithTx(ctx, tx)); err != nil {
+	err := fn(contextWithTx(ctx, tx))
+	if err != nil {
 		return err
 	}
-	return tx.Commit().Error
+
+	err = tx.Commit().Error
+	if err != nil {
+		return fmt.Errorf("error committing transaction: %w", err)
+	}
+	committed = true
+
+	return nil
 }

--- a/backend/internal/oidc/userinfo_handler.go
+++ b/backend/internal/oidc/userinfo_handler.go
@@ -49,6 +49,13 @@ func (h *userInfoHandler) userInfo(c *gin.Context) {
 		return
 	}
 
+	// userinfo is one of Pocket ID's own identity endpoints so it must only serve tokens audienced to Pocket ID itself
+	// A token audienced to a custom API belongs to that third-party resource server and must never be replayed here to read the user's profile, independent of the identity scopes already stripped from such a token
+	if targetsCustomAPI(accessRequest) {
+		writeUserInfoError(c, fosite.ErrAccessDenied.WithDescription("The access token is audienced to a custom API and cannot be used to access user information."))
+		return
+	}
+
 	// userinfo serves OIDC identity tokens, which are exactly the ones granted the openid scope
 	// An access token issued purely for a custom API never carries openid and is rejected here regardless of its audience
 	if !accessRequest.GetGrantedScopes().Has("openid") {

--- a/backend/internal/oidc/userinfo_handler.go
+++ b/backend/internal/oidc/userinfo_handler.go
@@ -13,12 +13,14 @@ import (
 type userInfoHandler struct {
 	provider      fosite.OAuth2Provider
 	claimsService *ClaimsService
+	issuer        string
 }
 
-func newUserInfoHandler(provider fosite.OAuth2Provider, claimsService *ClaimsService) *userInfoHandler {
+func newUserInfoHandler(provider fosite.OAuth2Provider, claimsService *ClaimsService, issuer string) *userInfoHandler {
 	return &userInfoHandler{
 		provider:      provider,
 		claimsService: claimsService,
+		issuer:        issuer,
 	}
 }
 
@@ -49,10 +51,10 @@ func (h *userInfoHandler) userInfo(c *gin.Context) {
 		return
 	}
 
-	// userinfo is one of Pocket ID's own identity endpoints so it must only serve tokens audienced to Pocket ID itself
-	// A token audienced to a custom API belongs to that third-party resource server and must never be replayed here to read the user's profile, independent of the identity scopes already stripped from such a token
-	if targetsCustomAPI(accessRequest) {
-		writeUserInfoError(c, fosite.ErrAccessDenied.WithDescription("The access token is audienced to a custom API and cannot be used to access user information."))
+	// userinfo is one of Pocket ID's own identity endpoints, so the presented token must be audienced to Pocket ID itself (the issuer)
+	// A token granted an identity scope carries the issuer audience and is accepted here even when it also targets a custom API, while a token audienced only to a custom API belongs to that third-party resource server and cannot be replayed here to read the user's profile
+	if !accessRequest.GetGrantedAudience().Has(h.issuer) {
+		writeUserInfoError(c, fosite.ErrAccessDenied.WithDescription("The access token is not audienced to this server and cannot be used to access user information."))
 		return
 	}
 

--- a/backend/internal/oidc/userinfo_handler_test.go
+++ b/backend/internal/oidc/userinfo_handler_test.go
@@ -127,6 +127,30 @@ func TestUserInfoHandler(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, rec.Code)
 	})
 
+	t.Run("token audienced to a custom API cannot read userinfo even when openid was granted", func(t *testing.T) {
+		session := NewEmptySession()
+		session.Subject = userID
+		session.SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(time.Hour))
+
+		request := fosite.NewAccessRequest(session)
+		request.ID = "req-api-audience"
+		request.Client = Client{OidcClient: model.OidcClient{Base: model.Base{ID: clientID}}}
+		request.GrantTypes = fosite.Arguments{string(fosite.GrantTypeClientCredentials)}
+		request.RequestedScope = fosite.Arguments{"openid", "email", "read:orders"}
+		request.GrantedScope = fosite.Arguments{"openid", "email", "read:orders"}
+		request.RequestedAudience = fosite.Arguments{"https://api.orders.example.com"}
+		request.GrantedAudience = fosite.Arguments{"https://api.orders.example.com"}
+
+		response, err := provider.NewAccessResponse(t.Context(), request)
+		require.NoError(t, err)
+
+		rec, c := call(t, response.GetAccessToken())
+		require.Empty(t, c.Errors)
+		require.Equal(t, http.StatusForbidden, rec.Code)
+		// The audience guard rejects it independently of the stripped identity scopes
+		require.Contains(t, rec.Body.String(), "audienced to a custom API")
+	})
+
 	t.Run("token whose user no longer exists is rejected with 401", func(t *testing.T) {
 		// A valid token whose subject was deleted is an auth failure, not a 404
 		token := issueAccessToken(t, "req-ghost", "ghost-user", "openid")

--- a/backend/internal/oidc/userinfo_handler_test.go
+++ b/backend/internal/oidc/userinfo_handler_test.go
@@ -1,8 +1,9 @@
 package oidc
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -43,7 +44,7 @@ func TestUserInfoHandler(t *testing.T) {
 		EmailVerified: true,
 	}).Error)
 
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
 	provider, err := newProvider(NewStore(db, nil), nil, testTokenSigner{key: key}, Config{

--- a/backend/internal/oidc/userinfo_handler_test.go
+++ b/backend/internal/oidc/userinfo_handler_test.go
@@ -47,14 +47,14 @@ func TestUserInfoHandler(t *testing.T) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
-	provider, err := newProvider(NewStore(db, nil), nil, testTokenSigner{key: key}, Config{
+	provider, err := newProvider(NewStore(db, nil).WithIssuer(baseURL), nil, testTokenSigner{key: key}, Config{
 		BaseURL:      baseURL,
 		TokenBaseURL: baseURL,
 		Secret:       []byte("test-secret"),
 	})
 	require.NoError(t, err)
 
-	handler := newUserInfoHandler(provider, newClaimsService(db, nil, baseURL, nil))
+	handler := newUserInfoHandler(provider, newClaimsService(db, nil, baseURL, nil), baseURL)
 
 	issueAccessToken := func(t *testing.T, requestID, subject string, scopes ...string) string {
 		t.Helper()
@@ -68,7 +68,8 @@ func TestUserInfoHandler(t *testing.T) {
 		request.GrantTypes = fosite.Arguments{string(fosite.GrantTypeClientCredentials)}
 		request.RequestedScope = fosite.Arguments(scopes)
 		request.GrantedScope = fosite.Arguments(scopes)
-		// A login token is audienced to the requesting client; userinfo gates on the openid scope, not the audience
+		// The grant is bound to the requesting client
+		// The issuer store adds the issuer audience when the token carries an identity scope, which is what userinfo gates on
 		request.RequestedAudience = fosite.Arguments{clientID}
 		request.GrantedAudience = fosite.Arguments{clientID}
 
@@ -128,7 +129,8 @@ func TestUserInfoHandler(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, rec.Code)
 	})
 
-	t.Run("token audienced to a custom API cannot read userinfo even when openid was granted", func(t *testing.T) {
+	t.Run("token audienced to a custom API can read userinfo when openid was granted", func(t *testing.T) {
+		// A token that requested identity scopes alongside a custom API resource is materialized with the issuer added to its audience, so it may read userinfo by the client's explicit opt-in
 		session := NewEmptySession()
 		session.Subject = userID
 		session.SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(time.Hour))
@@ -147,9 +149,36 @@ func TestUserInfoHandler(t *testing.T) {
 
 		rec, c := call(t, response.GetAccessToken())
 		require.Empty(t, c.Errors)
+		require.Equal(t, http.StatusOK, rec.Code)
+
+		var claims map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &claims))
+		require.Equal(t, userID, claims["sub"])
+		require.Equal(t, "tim@example.com", claims["email"])
+	})
+
+	t.Run("token audienced only to a custom API is rejected", func(t *testing.T) {
+		// A token that carries no identity scope never gains the issuer audience, so it cannot be replayed at userinfo even though it has a valid resource owner
+		session := NewEmptySession()
+		session.Subject = userID
+		session.SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(time.Hour))
+
+		request := fosite.NewAccessRequest(session)
+		request.ID = "req-api-only"
+		request.Client = Client{OidcClient: model.OidcClient{Base: model.Base{ID: clientID}}}
+		request.GrantTypes = fosite.Arguments{string(fosite.GrantTypeClientCredentials)}
+		request.RequestedScope = fosite.Arguments{"read:orders"}
+		request.GrantedScope = fosite.Arguments{"read:orders"}
+		request.RequestedAudience = fosite.Arguments{"https://api.orders.example.com"}
+		request.GrantedAudience = fosite.Arguments{"https://api.orders.example.com"}
+
+		response, err := provider.NewAccessResponse(t.Context(), request)
+		require.NoError(t, err)
+
+		rec, c := call(t, response.GetAccessToken())
+		require.Empty(t, c.Errors)
 		require.Equal(t, http.StatusForbidden, rec.Code)
-		// The audience guard rejects it independently of the stripped identity scopes
-		require.Contains(t, rec.Body.String(), "audienced to a custom API")
+		require.Contains(t, rec.Body.String(), "not audienced to this server")
 	})
 
 	t.Run("token whose user no longer exists is rejected with 401", func(t *testing.T) {

--- a/backend/internal/service/e2etest_service.go
+++ b/backend/internal/service/e2etest_service.go
@@ -833,7 +833,9 @@ type fositeTokenSession struct {
 func (s *TestService) seedFositeTokenSession(ctx context.Context, session fositeTokenSession) error {
 	request := s.newFositeTokenRequest(session)
 
-	store := oidc.NewStore(s.db, nil)
+	store := oidc.
+		NewStore(s.db, nil).
+		WithIssuer(common.EnvConfig.AppURL)
 	switch session.Kind {
 	case "access_token":
 		return store.CreateAccessTokenSession(ctx, session.Signature, request)

--- a/frontend/src/lib/components/scope-list.svelte
+++ b/frontend/src/lib/components/scope-list.svelte
@@ -8,7 +8,7 @@
 	let { scopes, scopeInfo = [] }: { scopes: string[]; scopeInfo?: InteractionScopeInfo[] } =
 		$props();
 
-	const standardScopes = ['openid', 'profile', 'email', 'groups'];
+	const standardScopes = ['openid', 'profile', 'email', 'groups', 'offline_access'];
 	const infoByKey = $derived(new Map(scopeInfo.map((info) => [info.key, info])));
 	const customScopes = $derived(scopes.filter((scope) => !standardScopes.includes(scope)));
 </script>

--- a/frontend/src/lib/components/ui/card/card-description.svelte
+++ b/frontend/src/lib/components/ui/card/card-description.svelte
@@ -13,7 +13,7 @@
 <p
 	bind:this={ref}
 	data-slot="card-description"
-	class={cn('text-muted-foreground text-sm', className)}
+	class={cn('text-muted-foreground text-sm mt-3', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/frontend/src/lib/types/oidc.type.ts
+++ b/frontend/src/lib/types/oidc.type.ts
@@ -43,7 +43,10 @@ export type OidcClientWithAllowedUserGroupsCount = OidcClient & {
 	allowedUserGroupsCount: number;
 };
 
-export type OidcClientUpdate = Omit<OidcClient, 'id' | 'logoURL' | 'hasLogo' | 'hasDarkLogo' | 'pkceSupported'>;
+export type OidcClientUpdate = Omit<
+	OidcClient,
+	'id' | 'logoURL' | 'hasLogo' | 'hasDarkLogo' | 'pkceSupported'
+>;
 export type OidcClientCreate = OidcClientUpdate & {
 	id?: string;
 };
@@ -61,6 +64,7 @@ export type OidcClientCreateWithLogo = OidcClientCreate & {
 
 export type OidcDeviceCodeInfo = {
 	scope: string[];
+	scopeInfo: InteractionScopeInfo[];
 	authorizationRequired: boolean;
 	reauthenticationRequired: boolean;
 	client: OidcClientMetaData;

--- a/frontend/src/routes/device/+page.svelte
+++ b/frontend/src/routes/device/+page.svelte
@@ -132,7 +132,7 @@
 					</p>
 				</Card.Header>
 				<Card.Content data-testid="scopes">
-					<ScopeList scopes={deviceInfo!.scope} />
+					<ScopeList scopes={deviceInfo!.scope} scopeInfo={deviceInfo!.scopeInfo} />
 				</Card.Content>
 			</Card.Root>
 		</div>

--- a/tests/specs/api.spec.ts
+++ b/tests/specs/api.spec.ts
@@ -146,7 +146,8 @@ test('Grant a client user-delegated and client access to API permissions', async
 // ---------------------------------------------------------------------------
 
 test('Authorization with a resource parameter issues a token audienced to that API', async ({
-	page
+	page,
+	baseURL
 }) => {
 	const client = oidcClients.immich;
 	const api = apis.orders;
@@ -183,7 +184,15 @@ test('Authorization with a resource parameter issues a token audienced to that A
 
 	const claims = jose.decodeJwt(res.access_token!);
 	expect(tokenAudiences(claims)).toContain(api.resource);
+	// Because openid was requested alongside the resource, the token also carries the issuer audience so it can still reach /userinfo
+	expect(tokenAudiences(claims)).toContain(baseURL);
 	expect(tokenScopes(claims)).toContain(api.permissions.readOrders.key);
+
+	// The same token can be presented at userinfo, by the client's explicit opt-in of requesting openid
+	const userinfo = await page.request.get('/api/oidc/userinfo', {
+		headers: { Authorization: 'Bearer ' + res.access_token }
+	});
+	expect(userinfo.status()).toBe(200);
 });
 
 test('Consent screen shows the friendly permission name for a resource request', async ({

--- a/tests/specs/oidc.spec.ts
+++ b/tests/specs/oidc.spec.ts
@@ -398,7 +398,8 @@ test.describe('Introspection endpoint', () => {
 		expect(introspectionBody.active).toBe(true);
 		expect(introspectionBody.iss).toBe(baseURL);
 		expect(introspectionBody.sub).toBe(users.tim.id);
-		expect(introspectionBody.aud).toStrictEqual([oidcClients.nextcloud.id]);
+		// An identity access token is audienced to the client and additionally to the issuer, so it can be presented at /userinfo
+		expect(introspectionBody.aud).toStrictEqual([oidcClients.nextcloud.id, baseURL]);
 	});
 
 	test('succeeds with federated client credentials', async ({ page, request, baseURL }) => {
@@ -427,7 +428,8 @@ test.describe('Introspection endpoint', () => {
 		expect(introspectionBody.active).toBe(true);
 		expect(introspectionBody.iss).toBe(baseURL);
 		expect(introspectionBody.sub).toBe(users.tim.id);
-		expect(introspectionBody.aud).toStrictEqual([oidcClients.federated.id]);
+		// An identity access token is audienced to the client and additionally to the issuer, so it can be presented at /userinfo
+		expect(introspectionBody.aud).toStrictEqual([oidcClients.federated.id, baseURL]);
 	});
 
 	test('fails with client credentials for wrong app', async ({ request }) => {


### PR DESCRIPTION
**This PR is built on top of #1542**

## Description

A few fixes:

1. Tokens issued to a custom audience _only_ cannot invoke the `/userinfo` endpoint in Pocket ID. When requesting the `openid` scope (or `email`, `profile`), tokens are now created with the added audience of `https://<pocket-id-address>/`, which grants access to the `/userinfo` endpoint too (so, tokens may have more than one audience).  Also makes the `/userinfo` endpoint enforce that tokens have the audience of Pocket ID itself, in addition to the openid scope.
2. Fixes some minor bugs, including the log message "transaction already committed" after successful transactions for fosite
3. UI: offline_access should be rendered as a built-in API
4. UI: device flow consent page cna't show description for custom audiences
5. Reject duplicate API permission keys rather than just collapsing them, since that indicates a request error
6. Ensure that errors do not disclose available APIs
7. Reject multiple `resource` parameters
8. Added more tests (also switched keys in test from RSA to ECDSA, since they generate "instantly")

## AI usage

This PR includes a mix of hand-written changes and changes made by Opus under my supervision, especially for writing the added tests. I have also used Claude to do some additional code review, which highlighted a few of the bugs/issues below.