### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Pocket ID can be set up in multiple ways. The easiest and recommended way is to 
 
 Visit the [documentation](https://docs.pocket-id.org) for the setup guide and more information.
 
+Prefer not to self-host? You can also get a managed instance in one click:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/pocket-id)
+
 ## Contribute
 
 You're very welcome to contribute to Pocket ID! Please follow the [contribution guide](/CONTRIBUTING.md) to get started.


### PR DESCRIPTION
## What does this PR do?

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Pocket ID to our marketplace, so this PR adds a small "Deploy with Zenith" badge to the Setup section of the README (links to https://zenith.hosting/host/pocket-id).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

## Screenshots

n/a, docs-only change (one additions-only line in the README).

## AI Usage

used an LLM to help draft this PR text and find the right spot for the badge line. it is a one-line docs addition, and i reviewed and checked it myself.

## Contributing Guidelines

Have you read the [Contributing Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md)?

- [ ] If I'm implementing a new feature, I have opened an issue first, or commented on an existing one, to discuss the implementation details.
- [x] I have read the [AI Usage Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md#ai-usage-policy).
