### PR TITLE
fix: postgres migration 20250822 remove public schema references

### DIFF
--- a/backend/resources/migrations/postgres/20250822000000_foreign_keys_improvements.down.sql
+++ b/backend/resources/migrations/postgres/20250822000000_foreign_keys_improvements.down.sql
@@ -1,7 +1,7 @@
-ALTER TABLE public.audit_logs
+ALTER TABLE audit_logs
     DROP CONSTRAINT IF EXISTS audit_logs_user_id_fkey,
     ADD CONSTRAINT audit_logs_user_id_fkey
-        FOREIGN KEY (user_id) REFERENCES public.users (id);
+        FOREIGN KEY (user_id) REFERENCES users (id);
 
-ALTER TABLE public.oidc_authorization_codes
+ALTER TABLE oidc_authorization_codes
     DROP CONSTRAINT IF EXISTS oidc_authorization_codes_client_fk;

--- a/backend/resources/migrations/postgres/20250822000000_foreign_keys_improvements.up.sql
+++ b/backend/resources/migrations/postgres/20250822000000_foreign_keys_improvements.up.sql
@@ -1,8 +1,8 @@
-ALTER TABLE public.audit_logs
+ALTER TABLE audit_logs
     DROP CONSTRAINT IF EXISTS audit_logs_user_id_fkey,
     ADD CONSTRAINT audit_logs_user_id_fkey
-        FOREIGN KEY (user_id) REFERENCES public.users (id) ON DELETE CASCADE;
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE;
 
-ALTER TABLE public.oidc_authorization_codes
+ALTER TABLE oidc_authorization_codes
     ADD CONSTRAINT oidc_authorization_codes_client_fk
-        FOREIGN KEY (client_id) REFERENCES public.oidc_clients (id) ON DELETE CASCADE;
+        FOREIGN KEY (client_id) REFERENCES oidc_clients (id) ON DELETE CASCADE;


### PR DESCRIPTION
## What does this PR do?
Fix PostgreSQL migration 20250822 (`20250822000000_foreign_keys_improvements`) removing the explicit reference to the default `public` database schema. Every other migraiton does not explicitly reference a schema, making the entire migration suite able to run on any schema. This particular migration breaks that pattern and causes a fresh install in PostgreSQL in any schema other than `public` to fail. 

## Screenshots
Not relevant

## AI Usage
None

## Contributing Guidelines

Have you read the [Contributing Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md)?

- [x] I have read the [AI Usage Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md#ai-usage-policy).
