### PR TITLE
fix: relax Francis DB usage while HA is still WIP

### DIFF
--- a/backend/internal/bootstrap/actors_bootstrap.go
+++ b/backend/internal/bootstrap/actors_bootstrap.go
@@ -49,6 +49,12 @@ func NewActors(o NewActorsOpts) (*local.Host, map[string]*ratelimit.RateLimitSer
 		local.WithLogger(log.With("scope", "actor-host")),
 		local.WithRuntimePSKs(psk),
 		local.WithShutdownGracePeriod(10 * time.Second),
+		// TODO: Tweak these values once Pocket ID fully supports horizontal scaling.
+		// The relaxed intervals are appropriate for a single active host, but should be
+		// tuned for lower latency and better distribution across a multi-host cluster.
+		local.WithHostHealthCheckDeadline(90 * time.Second),
+		local.WithAlarmsPollInterval(5 * time.Minute),
+		local.WithAlarmsFetchAheadInterval(5 * time.Minute),
 	}
 
 	// Add the database connection


### PR DESCRIPTION
## What does this PR do?

Currently the Francis actor framework is configured with intervals that are appropriate for multiple instances, but cause increase load on the DB (see #1598 and other issue reports). This is compounded by the fact that Pocket ID itself is still performing health checks every 30s that we can’t remove yet.

Until proper HA mode is supported, we can relax these values to decrease DB load significantly.

For now there’s a TODO comment to revise them when HA is done. We may still consider adding a “non-HA” mode with reduced resource usage in the future.

The relaxed values set on the actor host:

- `WithHostHealthCheckDeadline` — 90s
- `WithAlarmsPollInterval` — 5m
- `WithAlarmsFetchAheadInterval` — 5m

## AI Usage

This change was drafted with AI assistance and reviewed by a human before submission.
