### PR TITLE
feat: support redirect URLs after passkey setup

### DIFF
--- a/backend/internal/controller/oidc_controller.go
+++ b/backend/internal/controller/oidc_controller.go
@@ -38,6 +38,8 @@ func NewOidcController(group *gin.RouterGroup, authMiddleware *middleware.AuthMi
 	group.DELETE("/oidc/clients/:id/logo", authMiddleware.Add(), oc.deleteClientLogoHandler)
 	group.POST("/oidc/clients/:id/logo", authMiddleware.Add(), fileSizeLimitMiddleware.Add(2<<20), oc.updateClientLogoHandler)
 
+	group.GET("/oidc/redirect-uri/registered", authMiddleware.WithAdminNotRequired().Add(), oc.getRegisteredRedirectURIHandler)
+
 	group.GET("/oidc/clients/:id/preview/:userId", authMiddleware.Add(), oc.getClientPreviewHandler)
 
 	group.GET("/oidc/users/me/authorized-clients", authMiddleware.WithAdminNotRequired().Add(), oc.listOwnAuthorizedClientsHandler)
@@ -149,6 +151,19 @@ func (oc *OidcController) listClientsHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, dto.Paginated[dto.OidcClientWithAllowedGroupsCountDto]{
 		Data:       clientsDto,
 		Pagination: pagination,
+	})
+}
+
+func (oc *OidcController) getRegisteredRedirectURIHandler(c *gin.Context) {
+	redirectURI, err := oc.oidcService.GetRegisteredCallbackURL(c.Request.Context(), c.Query("redirect_uri"))
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, dto.OidcRegisteredCallbackURLDto{
+		Registered:  redirectURI != "",
+		RedirectURI: redirectURI,
 	})
 }
 

--- a/backend/internal/dto/oidc_dto.go
+++ b/backend/internal/dto/oidc_dto.go
@@ -73,6 +73,11 @@ type OidcUpdateAllowedUserGroupsDto struct {
 	UserGroupIDs []string `json:"userGroupIds" binding:"required"`
 }
 
+type OidcRegisteredCallbackURLDto struct {
+	Registered  bool   `json:"registered"`
+	RedirectURI string `json:"redirectURI,omitempty"`
+}
+
 type OidcLogoutDto struct {
 	IdTokenHint           string `form:"id_token_hint"`
 	ClientId              string `form:"client_id"`

--- a/backend/internal/oidc/provider.go
+++ b/backend/internal/oidc/provider.go
@@ -46,7 +46,7 @@ func newProvider(store *Store, authenticator *federatedClientAuthenticator, sign
 		TokenURL:                       config.TokenBaseURL + "/api/oidc/token",
 		ScopeStrategy:                  fosite.ExactScopeStrategy,
 		AudienceMatchingStrategy:       fosite.ExactAudienceMatchingStrategy,
-		RedirectURIMatcher:             matchRedirectURI,
+		RedirectURIMatcher:             MatchRedirectURI,
 		EnforcePKCEForPublicClients:    true,
 		EnablePKCEPlainChallengeMethod: true,
 		FormPostHTMLTemplate:           formPostTemplate,
@@ -103,7 +103,8 @@ func newProvider(store *Store, authenticator *federatedClientAuthenticator, sign
 	}, nil
 }
 
-func matchRedirectURI(rawurl string, client fosite.Client) (*url.URL, error) {
+// MatchRedirectURI validates a requested redirect URI against a client's registered redirect URIs
+func MatchRedirectURI(rawurl string, client fosite.Client) (*url.URL, error) {
 	redirectURI, err := fosite.MatchRedirectURIWithClientRedirectURIs(rawurl, client)
 	if err == nil || rawurl == "" {
 		return redirectURI, err

--- a/backend/internal/service/oidc_service.go
+++ b/backend/internal/service/oidc_service.go
@@ -130,7 +130,7 @@ func (s *OidcService) GetRegisteredCallbackURL(ctx context.Context, redirectURI 
 	}
 
 	var clients []model.OidcClient
-	err = s.db.
+	err := s.db.
 		WithContext(ctx).
 		Select("callback_urls").
 		Find(&clients).

--- a/backend/internal/service/oidc_service.go
+++ b/backend/internal/service/oidc_service.go
@@ -120,6 +120,56 @@ func (s *OidcService) ListClients(ctx context.Context, name string, listRequestO
 	return clients, response, err
 }
 
+func (s *OidcService) GetRegisteredCallbackURL(ctx context.Context, redirectURI string) (string, error) {
+	if redirectURI == "" {
+		return "", nil
+	}
+
+	if !isValidRequestedCallbackURL(redirectURI) {
+		return "", nil
+	}
+
+	var clients []model.OidcClient
+	err = s.db.
+		WithContext(ctx).
+		Select("callback_urls").
+		Find(&clients).
+		Error
+	if err != nil {
+		return "", err
+	}
+
+	for _, client := range clients {
+		matchedURL, err := utils.GetCallbackURLFromList(client.CallbackURLs, redirectURI)
+		if err != nil {
+			return "", err
+		}
+		if matchedURL != "" {
+			return matchedURL, nil
+		}
+	}
+
+	return "", nil
+}
+
+func isValidRequestedCallbackURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Scheme == "" || u.Fragment != "" {
+		return false
+	}
+
+	switch strings.ToLower(u.Scheme) {
+	case "javascript", "data":
+		return false
+	}
+
+	if (u.Scheme == "http" || u.Scheme == "https") && u.Host == "" {
+		return false
+	}
+
+	return true
+}
+
 func (s *OidcService) CreateClient(ctx context.Context, input dto.OidcClientCreateDto, userID string) (model.OidcClient, error) {
 	client := model.OidcClient{
 		Base: model.Base{

--- a/backend/internal/service/oidc_service.go
+++ b/backend/internal/service/oidc_service.go
@@ -125,10 +125,6 @@ func (s *OidcService) GetRegisteredCallbackURL(ctx context.Context, redirectURI 
 		return "", nil
 	}
 
-	if !isValidRequestedCallbackURL(redirectURI) {
-		return "", nil
-	}
-
 	var clients []model.OidcClient
 	err := s.db.
 		WithContext(ctx).
@@ -140,34 +136,13 @@ func (s *OidcService) GetRegisteredCallbackURL(ctx context.Context, redirectURI 
 	}
 
 	for _, client := range clients {
-		matchedURL, err := utils.GetCallbackURLFromList(client.CallbackURLs, redirectURI)
-		if err != nil {
-			return "", err
-		}
-		if matchedURL != "" {
-			return matchedURL, nil
+		matchedURL, err := oidc.MatchRedirectURI(redirectURI, oidc.Client{OidcClient: client})
+		if err == nil && matchedURL != nil {
+			return matchedURL.String(), nil
 		}
 	}
 
 	return "", nil
-}
-
-func isValidRequestedCallbackURL(rawURL string) bool {
-	u, err := url.Parse(rawURL)
-	if err != nil || u.Scheme == "" || u.Fragment != "" {
-		return false
-	}
-
-	switch strings.ToLower(u.Scheme) {
-	case "javascript", "data":
-		return false
-	}
-
-	if (u.Scheme == "http" || u.Scheme == "https") && u.Host == "" {
-		return false
-	}
-
-	return true
 }
 
 func (s *OidcService) CreateClient(ctx context.Context, input dto.OidcClientCreateDto, userID string) (model.OidcClient, error) {

--- a/backend/internal/service/oidc_service_test.go
+++ b/backend/internal/service/oidc_service_test.go
@@ -186,7 +186,7 @@ func TestOidcService_GetRegisteredCallbackURL(t *testing.T) {
 			input: "https://evil.example/steal",
 		},
 		{
-			name:  "callback URL with fragment is rejected before matcher ignores it",
+			name:  "callback URL with fragment is rejected by the OIDC redirect matcher",
 			input: "https://example.com/callback#fragment",
 		},
 		{
@@ -203,7 +203,7 @@ func TestOidcService_GetRegisteredCallbackURL(t *testing.T) {
 		})
 	}
 
-	t.Run("relative URL is rejected before a global wildcard can match it", func(t *testing.T) {
+	t.Run("relative URL is rejected by the OIDC redirect matcher even with a global wildcard", func(t *testing.T) {
 		require.NoError(t, db.Create(&model.OidcClient{
 			Base:         model.Base{ID: "wildcard-client"},
 			Name:         "Wildcard Client",

--- a/backend/internal/service/oidc_service_test.go
+++ b/backend/internal/service/oidc_service_test.go
@@ -148,6 +148,74 @@ func TestOidcService_updateClientLogoType(t *testing.T) {
 	})
 }
 
+func TestOidcService_GetRegisteredCallbackURL(t *testing.T) {
+	db := testutils.NewDatabaseForTest(t)
+	s := &OidcService{db: db}
+
+	require.NoError(t, db.Create(&model.OidcClient{
+		Base: model.Base{ID: "client-one"},
+		Name: "Client One",
+		CallbackURLs: model.UrlList{
+			"https://example.com/callback",
+			"https://*.example.org/callback",
+		},
+	}).Error)
+	require.NoError(t, db.Create(&model.OidcClient{
+		Base:         model.Base{ID: "client-two"},
+		Name:         "Client Two",
+		CallbackURLs: model.UrlList{"https://client.example.net/oauth/callback"},
+	}).Error)
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "exact callback URL is returned",
+			input:    "https://example.com/callback",
+			expected: "https://example.com/callback",
+		},
+		{
+			name:     "wildcard matching delegates to the shared callback URL matcher",
+			input:    "https://tenant.example.org/callback",
+			expected: "https://tenant.example.org/callback",
+		},
+		{
+			name:  "unknown external URL is rejected",
+			input: "https://evil.example/steal",
+		},
+		{
+			name:  "callback URL with fragment is rejected before matcher ignores it",
+			input: "https://example.com/callback#fragment",
+		},
+		{
+			name:  "missing URL is rejected",
+			input: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.GetRegisteredCallbackURL(t.Context(), tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+
+	t.Run("relative URL is rejected before a global wildcard can match it", func(t *testing.T) {
+		require.NoError(t, db.Create(&model.OidcClient{
+			Base:         model.Base{ID: "wildcard-client"},
+			Name:         "Wildcard Client",
+			CallbackURLs: model.UrlList{"*"},
+		}).Error)
+
+		got, err := s.GetRegisteredCallbackURL(t.Context(), "/settings/account")
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+}
+
 func TestOidcService_downloadAndSaveLogoFromURL(t *testing.T) {
 	const publicLogoHost = "https://8.8.8.8"
 

--- a/frontend/src/lib/services/oidc-service.ts
+++ b/frontend/src/lib/services/oidc-service.ts
@@ -10,7 +10,8 @@ import type {
 	OidcClientUpdate,
 	OidcClientWithAllowedUserGroups,
 	OidcClientWithAllowedUserGroupsCount,
-	OidcDeviceCodeInfo
+	OidcDeviceCodeInfo,
+	RegisteredCallbackURL
 } from '$lib/types/oidc.type';
 import type { ScimServiceProvider } from '$lib/types/scim.type';
 import { cachedOidcClientLogo } from '$lib/utils/cached-image-util';
@@ -35,6 +36,13 @@ class OidcService extends APIService {
 			params: options
 		});
 		return res.data as Paginated<OidcClientWithAllowedUserGroupsCount>;
+	};
+
+	getRegisteredCallbackURL = async (redirectURI: string) => {
+		const res = await this.api.get('/oidc/redirect-uri/registered', {
+			params: { redirect_uri: redirectURI }
+		});
+		return res.data as RegisteredCallbackURL;
 	};
 
 	createClient = async (client: OidcClientCreate) =>

--- a/frontend/src/lib/types/oidc.type.ts
+++ b/frontend/src/lib/types/oidc.type.ts
@@ -43,7 +43,10 @@ export type OidcClientWithAllowedUserGroupsCount = OidcClient & {
 	allowedUserGroupsCount: number;
 };
 
-export type OidcClientUpdate = Omit<OidcClient, 'id' | 'logoURL' | 'hasLogo' | 'hasDarkLogo' | 'pkceSupported'>;
+export type OidcClientUpdate = Omit<
+	OidcClient,
+	'id' | 'logoURL' | 'hasLogo' | 'hasDarkLogo' | 'pkceSupported'
+>;
 export type OidcClientCreate = OidcClientUpdate & {
 	id?: string;
 };
@@ -83,4 +86,9 @@ export type InteractionSession = {
 export type CompleteInteractionResponse = {
 	interaction?: InteractionSession;
 	redirectUrl?: string;
+};
+
+export type RegisteredCallbackURL = {
+	registered: boolean;
+	redirectURI?: string;
 };

--- a/frontend/src/routes/signup/add-passkey/+page.svelte
+++ b/frontend/src/routes/signup/add-passkey/+page.svelte
@@ -60,7 +60,7 @@
 	}
 
 	async function redirectAfterSkippingPasskeySetup() {
-		const redirectPath = await getValidatedCallbackURLFromQueryParam('cancel_url');
+		const redirectPath = await getValidatedCallbackURLFromQueryParam('cancel_uri');
 		if (redirectPath === accountSettingsPath) {
 			await goto(redirectPath);
 			return;

--- a/frontend/src/routes/signup/add-passkey/+page.svelte
+++ b/frontend/src/routes/signup/add-passkey/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import { openConfirmDialog } from '$lib/components/confirm-dialog';
 	import SignInWrapper from '$lib/components/login-wrapper.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { m } from '$lib/paraglide/messages';
+	import OIDCService from '$lib/services/oidc-service';
 	import WebAuthnService from '$lib/services/webauthn-service';
 	import { getWebauthnErrorMessage } from '$lib/utils/error-util';
 	import { tryCatch } from '$lib/utils/try-catch-util';
@@ -11,6 +13,8 @@
 	import { fade } from 'svelte/transition';
 	import LoginLogoErrorSuccessIndicator from '../../login/components/login-logo-error-success-indicator.svelte';
 
+	const accountSettingsPath = '/settings/account';
+	const oidcService = new OIDCService();
 	const webauthnService = new WebAuthnService();
 
 	let isLoading = $state(false);
@@ -41,8 +45,42 @@
 			return;
 		}
 
-		goto('/settings/account');
+		await redirectAfterSuccessfulPasskeySetup();
 		isLoading = false;
+	}
+
+	async function redirectAfterSuccessfulPasskeySetup() {
+		const redirectPath = await getValidatedCallbackURLFromQueryParam('redirect_uri');
+		if (redirectPath === accountSettingsPath) {
+			await goto(redirectPath);
+			return;
+		}
+
+		window.location.href = redirectPath;
+	}
+
+	async function redirectAfterSkippingPasskeySetup() {
+		const redirectPath = await getValidatedCallbackURLFromQueryParam('cancel_url');
+		if (redirectPath === accountSettingsPath) {
+			await goto(redirectPath);
+			return;
+		}
+
+		window.location.href = redirectPath;
+	}
+
+	async function getValidatedCallbackURLFromQueryParam(queryParam: string) {
+		const callbackURL = page.url.searchParams.get(queryParam);
+		if (!callbackURL) {
+			return accountSettingsPath;
+		}
+
+		const result = await tryCatch(oidcService.getRegisteredCallbackURL(callbackURL));
+		if (result.error || !result.data.registered || !result.data.redirectURI) {
+			return accountSettingsPath;
+		}
+
+		return result.data.redirectURI;
 	}
 
 	function skipForNow() {
@@ -53,7 +91,7 @@
 				label: m.skip_for_now(),
 				destructive: true,
 				action: () => {
-					goto('/settings/account');
+					void redirectAfterSkippingPasskeySetup();
 				}
 			}
 		});


### PR DESCRIPTION
## What does this PR do?

Closes #1553.

This PR adds support for optional `redirect_uri` and `cancel_uri` query parameters on `/signup/add-passkey`.

* `redirect_uri` is used after successful passkey registration.
* `cancel_uri` is used when the user confirms that they want to skip passkey setup.
* Both parameters are optional.
* Supplied URLs are validated against the callback URLs registered for existing OIDC clients.
* The existing callback URL matching logic is reused, including wildcard support.
* Invalid, malformed, unregistered, relative, or otherwise unsafe URLs fall back to `/settings/account`.

The PR also adds an authenticated backend endpoint for checking whether a requested redirect URL is registered without exposing the list of OIDC clients to non-admin users.

Backend tests cover the new redirect validation behavior.

## Screenshots

No visual UI changes.

## AI Usage

I used an LLM to help review and refine parts of the implementation and the accompanying tests. I manually reviewed, adjusted, and tested the code and understand the submitted changes.

## Contributing Guidelines

Have you read the [Contributing Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md)?

* [x] If I'm implementing a new feature, I have opened an issue first, or commented on an existing one, to discuss the implementation details.
* [x] I have read the [AI Usage Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md#ai-usage-policy)