### PR TITLE
feat: declaritive user id configuration

### DIFF
--- a/backend/internal/dto/user_dto.go
+++ b/backend/internal/dto/user_dto.go
@@ -23,6 +23,7 @@ type UserDto struct {
 }
 
 type UserCreateDto struct {
+	ID            string   `json:"id" binding:"omitempty,uuid"`
 	Username      string   `json:"username" binding:"required,username,min=1,max=50" unorm:"nfc"`
 	Email         *string  `json:"email" binding:"omitempty,email" unorm:"nfc"`
 	EmailVerified bool     `json:"emailVerified"`

--- a/backend/internal/dto/user_dto_test.go
+++ b/backend/internal/dto/user_dto_test.go
@@ -24,6 +24,18 @@ func TestUserCreateDto_Validate(t *testing.T) {
 			wantErr: "",
 		},
 		{
+			name: "with custom id",
+			input: UserCreateDto{
+				ID:          "e8b81981-1c92-46e3-bfbf-07096560e6bb",
+				Username:    "testuser",
+				Email:       new("test@example.com"),
+				FirstName:   "John",
+				LastName:    "Doe",
+				DisplayName: "John Doe",
+			},
+			wantErr: "",
+		},
+		{
 			name: "missing username",
 			input: UserCreateDto{
 				Email:       new("test@example.com"),

--- a/backend/internal/service/user_service.go
+++ b/backend/internal/service/user_service.go
@@ -285,6 +285,9 @@ func (s *UserService) createUserInternal(ctx context.Context, input dto.UserCrea
 		Disabled:      input.Disabled,
 		UserGroups:    userGroups,
 	}
+	if input.ID != "" {
+		user.ID = input.ID
+	}
 	if input.LdapID != "" {
 		user.LdapID = &input.LdapID
 	}


### PR DESCRIPTION
This PR is part 2/2 which provides a bare minimum foundation to satisfy the needs described in https://github.com/pocket-id/pocket-id/issues/1574. See #1619 for part 1/2.

# Feature
* `POST /api/users` now accepts an additional _optional_ body parameter: `id` to deterministically set the user ID on creation.

## Points for Discussion
* Whether or not to integrate the new API capability to the frontend (i.e. allow to specify custom user IDs via the frontend)
* Whether the validation rule make sense: User ID must be a UUID (any version)

**Disclaimer:** No(!) AI was used in writing any of the code, nor this text.