### PR TITLE
fix: one-time-access-token CLI fails with "RuntimePSKs is required"

### DIFF
--- a/backend/internal/bootstrap/actors_bootstrap.go
+++ b/backend/internal/bootstrap/actors_bootstrap.go
@@ -115,19 +115,23 @@ func (o *NewActorsOpts) getPSK() ([]byte, error) {
 // NewActorStateStore creates a minimal actor host that can read and write actor state directly, without joining the cluster or binding a network port.
 // It's meant for short-lived contexts such as CLI commands that need to persist actor state (for example, one-time access tokens) without running the full actor host.
 // The returned host must NOT be Run(): only direct state operations (Get/Set/Delete on state) are supported, and they require the actor state tables to already exist, which is the case whenever the server has run at least once against this database.
-func NewActorStateStore(db *gorm.DB, pg *pgxpool.Pool) (*local.Host, error) {
-	opts := &NewActorsOpts{DB: db, Postgres: pg}
-	if pg == nil {
-		sqlDB, err := db.DB()
+func NewActorStateStore(o NewActorsOpts) (*local.Host, error) {
+	if o.Postgres == nil {
+		sqlDB, err := o.DB.DB()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get *sql.DB connection from Gorm: %w", err)
 		}
-		opts.SQLite = sqlDB
+		o.SQLite = sqlDB
 	}
 
-	providerOpt, err := opts.getProviderOption()
+	providerOpt, err := o.getProviderOption()
 	if err != nil {
 		return nil, err
+	}
+
+	psk, err := o.getPSK()
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive PSK: %w", err)
 	}
 
 	return local.NewHost(
@@ -136,6 +140,7 @@ func NewActorStateStore(db *gorm.DB, pg *pgxpool.Pool) (*local.Host, error) {
 		local.WithLogger(slog.Default().With("scope", "actor-state-store")),
 		// The health-check deadline only needs to exceed the provider's query timeout to pass validation
 		local.WithHostHealthCheckDeadline(90*time.Second),
+		local.WithRuntimePSKs(psk),
 		providerOpt,
 	)
 }

--- a/backend/internal/cmds/one_time_access_token.go
+++ b/backend/internal/cmds/one_time_access_token.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pocket-id/pocket-id/backend/internal/bootstrap"
 	"github.com/pocket-id/pocket-id/backend/internal/common"
+	"github.com/pocket-id/pocket-id/backend/internal/instanceid"
 	"github.com/pocket-id/pocket-id/backend/internal/model"
 	"github.com/pocket-id/pocket-id/backend/internal/onetimeaccess"
 )
@@ -47,9 +48,19 @@ var oneTimeAccessTokenCmd = &cobra.Command{
 			return errors.New("invalid user loaded: ID is empty")
 		}
 
+		instanceID, err := instanceid.Load(cmd.Context(), db)
+		if err != nil {
+			return err
+		}
+
 		// One-time access tokens are stored in the actor state store
 		// The CLI doesn't run the full actor host, so it uses a minimal state store to persist the token directly
-		actorStore, err := bootstrap.NewActorStateStore(db, pg)
+		actorStore, err := bootstrap.NewActorStateStore(bootstrap.NewActorsOpts{
+			DB:         db,
+			Postgres:   pg,
+			EnvConfig:  &common.EnvConfig,
+			InstanceID: instanceID,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to initialize the actor state store: %w", err)
 		}


### PR DESCRIPTION
## What does this PR do?

This PR addresses a regression introduced in a1b4e1d2 (PR #1611), which added [NewActorStateStore](https://github.com/pocket-id/pocket-id/blob/27199f61d4adaeca463db68980dae6c2a885c5b4/backend/internal/bootstrap/actors_bootstrap.go#L118-L141). It is my understanding that _NewActorStateStore_ is a stripped down version of [NewActors](https://github.com/pocket-id/pocket-id/blob/27199f61d4adaeca463db68980dae6c2a885c5b4/backend/internal/bootstrap/actors_bootstrap.go#L37-L106).
The latter derives a PSK from the global encryption key while the former, used by _one-time-access-token_ command, is missing that. This was merged in v2.12.0 and broke that functionality.

This PR basically adds the few lines of code necessary to load the instance ID and pass the missing runtime PSK inside _NewActorStateStore_, matching _NewActors_.

Closes #1634.

## Screenshots

N/A

## AI Usage

I had a few spare tokens and I used Claude Code to investigate the root cause and draft the fix. I reviewed the changes, verified them with go test, go vet, and go build, and I understand every line of the diff. I also built the Docker image and tested that as well.

## Contributing Guidelines

Have you read the [Contributing Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md)?

- [x] If I'm implementing a new feature, I have opened an issue first, or commented on an existing one, to discuss the implementation details.
- [x] I have read the [AI Usage Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md#ai-usage-policy).