### PR TITLE
fix: in non-HA mode, increase AlarmLeaseDuration

### DIFF
--- a/backend/internal/bootstrap/actors_bootstrap.go
+++ b/backend/internal/bootstrap/actors_bootstrap.go
@@ -63,11 +63,13 @@ func NewActors(o NewActorsOpts) (*local.Host, map[string]*ratelimit.RateLimitSer
 	}
 
 	// With a single active host the relaxed alarm intervals reduce database load
-	// When HA is enabled they are dropped so Francis uses its tighter defaults, which distribute alarm work and fail over faster across multiple hosts
+	// The longer lease duration also means fewer lease renewals, since Francis renews a lease 10s before it expires (no other host can claim the alarm anyways)
+	// When HA is enabled these are dropped so Francis uses its tighter defaults, which distribute alarm work and fail over faster across multiple hosts
 	if !o.EnvConfig.HAEnabled {
 		opts = append(opts,
 			local.WithAlarmsPollInterval(5*time.Minute),
 			local.WithAlarmsFetchAheadInterval(5*time.Minute),
+			local.WithAlarmsLeaseDuration(180*time.Second),
 		)
 	}
 


### PR DESCRIPTION
## What does this PR do?

Mirrors the work in #1602 and #1624 for alarm poll interval and health checks when in non-HA mode.

As verified in #1598, Francis was still performing a query to renew alarm leases every 10s, which is too quick in non-HA mode. Relaxing the duration to 180s which means that renewals are every 170s.

Note: in case of a non-clean shutdown (e.g. app crashes), alarm leases aren't released, so now it can take an average of 1.5 mins (half of 180s) until a new instance can pick up the alarms. Given what we use alarms for, this should be acceptable.

## AI Usage

Hand-rolled

## Contributing Guidelines

Have you read the [Contributing Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md)?

- [X] If I'm implementing a new feature, I have opened an issue first, or commented on an existing one, to discuss the implementation details.
- [X] I have read the [AI Usage Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md#ai-usage-policy).
