### PR TITLE
Allow additional WebAuthn origins via ADDITIONAL_WEBAUTHN_ORIGINS

### DIFF
--- a/backend/internal/bootstrap/services_bootstrap.go
+++ b/backend/internal/bootstrap/services_bootstrap.go
@@ -98,11 +98,12 @@ func initServices(
 
 	svc.customClaimService = service.NewCustomClaimService(db)
 	svc.webauthnModule, err = webauthn.New(webauthn.Dependencies{
-		DB:        db,
-		AppURL:    common.EnvConfig.AppURL,
-		Signer:    svc.jwtService,
-		AuditLog:  svc.auditLogService,
-		AppConfig: svc.appConfigService,
+		DB:                db,
+		AppURL:            common.EnvConfig.AppURL,
+		AdditionalOrigins: common.EnvConfig.AdditionalWebauthnOrigins,
+		Signer:            svc.jwtService,
+		AuditLog:          svc.auditLogService,
+		AppConfig:         svc.appConfigService,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create WebAuthn module: %w", err)

--- a/backend/internal/common/env_config.go
+++ b/backend/internal/common/env_config.go
@@ -43,6 +43,9 @@ type EnvConfigSchema struct {
 	AppEnv                    AppEnv `env:"APP_ENV" options:"toLower"`
 	EncryptionKey             []byte `env:"ENCRYPTION_KEY" options:"file"`
 	AppURL                    string `env:"APP_URL" options:"toLower,trimTrailingSlash"`
+	// Extra allowed WebAuthn origins besides AppURL (comma-separated), e.g.
+	// "android:apk-key-hash:..." for native app WebViews using Credential Manager.
+	AdditionalWebauthnOrigins []string `env:"ADDITIONAL_WEBAUTHN_ORIGINS"`
 	DbProvider                DbProvider
 	DbConnectionString        string           `env:"DB_CONNECTION_STRING" options:"file"`
 	TrustProxy                TrustProxyConfig `env:"TRUST_PROXY"`

--- a/backend/internal/webauthn/module.go
+++ b/backend/internal/webauthn/module.go
@@ -32,6 +32,9 @@ type AppConfigResolver interface {
 type Dependencies struct {
 	DB     *gorm.DB
 	AppURL string
+	// Extra allowed WebAuthn origins besides AppURL (e.g. Android apk-key-hash
+	// origins for native app WebViews).
+	AdditionalOrigins []string
 
 	Signer    TokenService
 	AuditLog  AuditLogger

--- a/backend/internal/webauthn/service.go
+++ b/backend/internal/webauthn/service.go
@@ -41,7 +41,7 @@ func newService(deps Dependencies) (*Service, error) {
 		// Set a default value, it will be set again later
 		RPDisplayName: defaultRPDisplayName,
 		RPID:          utils.GetHostnameFromURL(deps.AppURL),
-		RPOrigins:     []string{deps.AppURL},
+		RPOrigins:     append([]string{deps.AppURL}, deps.AdditionalOrigins...),
 		AuthenticatorSelection: protocol.AuthenticatorSelection{
 			UserVerification: protocol.VerificationRequired,
 		},


### PR DESCRIPTION
WebAuthn ceremonies from native app WebViews (Android Credential Manager with WebSettingsCompat.setWebAuthenticationSupport FOR_APP) sign an origin of the form android:apk-key-hash:<base64url(sha256(cert))> instead of the web origin. RPOrigins is currently hardcoded to AppURL, so such assertions are always rejected and self-hosted native apps cannot use Pocket ID passkeys inside their WebView.

This adds an optional comma-separated ADDITIONAL_WEBAUTHN_ORIGINS env var appended to RPOrigins. Default behavior is unchanged (empty list). go-webauthn compares non-URL origins by exact string match, so android:apk-key-hash origins work as-is.

## What does this PR do?

## Screenshots

## AI Usage

## Contributing Guidelines

Have you read the [Contributing Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md)?

- [ ] If I'm implementing a new feature, I have opened an issue first, or commented on an existing one, to discuss the implementation details.
- [ ] I have read the [AI Usage Guidelines](https://github.com/pocket-id/pocket-id/blob/main/CONTRIBUTING.md#ai-usage-policy).
