### PR TITLE
Allow additional WebAuthn origins via ADDITIONAL_WEBAUTHN_ORIGINS

### DIFF
--- a/backend/internal/bootstrap/services_bootstrap.go
+++ b/backend/internal/bootstrap/services_bootstrap.go
@@ -98,11 +98,12 @@ func initServices(
 
 	svc.customClaimService = service.NewCustomClaimService(db)
 	svc.webauthnModule, err = webauthn.New(webauthn.Dependencies{
-		DB:        db,
-		AppURL:    common.EnvConfig.AppURL,
-		Signer:    svc.jwtService,
-		AuditLog:  svc.auditLogService,
-		AppConfig: svc.appConfigService,
+		DB:                db,
+		AppURL:            common.EnvConfig.AppURL,
+		AdditionalOrigins: common.EnvConfig.AdditionalWebauthnOrigins,
+		Signer:            svc.jwtService,
+		AuditLog:          svc.auditLogService,
+		AppConfig:         svc.appConfigService,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create WebAuthn module: %w", err)

--- a/backend/internal/common/env_config.go
+++ b/backend/internal/common/env_config.go
@@ -43,6 +43,9 @@ type EnvConfigSchema struct {
 	AppEnv                    AppEnv `env:"APP_ENV" options:"toLower"`
 	EncryptionKey             []byte `env:"ENCRYPTION_KEY" options:"file"`
 	AppURL                    string `env:"APP_URL" options:"toLower,trimTrailingSlash"`
+	// Extra allowed WebAuthn origins besides AppURL (comma-separated), e.g.
+	// "android:apk-key-hash:..." for native app WebViews using Credential Manager.
+	AdditionalWebauthnOrigins []string `env:"ADDITIONAL_WEBAUTHN_ORIGINS"`
 	DbProvider                DbProvider
 	DbConnectionString        string           `env:"DB_CONNECTION_STRING" options:"file"`
 	TrustProxy                TrustProxyConfig `env:"TRUST_PROXY"`

--- a/backend/internal/webauthn/module.go
+++ b/backend/internal/webauthn/module.go
@@ -32,6 +32,9 @@ type AppConfigResolver interface {
 type Dependencies struct {
 	DB     *gorm.DB
 	AppURL string
+	// Extra allowed WebAuthn origins besides AppURL (e.g. Android apk-key-hash
+	// origins for native app WebViews).
+	AdditionalOrigins []string
 
 	Signer    TokenService
 	AuditLog  AuditLogger

--- a/backend/internal/webauthn/service.go
+++ b/backend/internal/webauthn/service.go
@@ -41,7 +41,7 @@ func newService(deps Dependencies) (*Service, error) {
 		// Set a default value, it will be set again later
 		RPDisplayName: defaultRPDisplayName,
 		RPID:          utils.GetHostnameFromURL(deps.AppURL),
-		RPOrigins:     []string{deps.AppURL},
+		RPOrigins:     append([]string{deps.AppURL}, deps.AdditionalOrigins...),
 		AuthenticatorSelection: protocol.AuthenticatorSelection{
 			UserVerification: protocol.VerificationRequired,
 		},


### PR DESCRIPTION
WebAuthn assertions from native app WebViews are always rejected. On Android, a WebView that enables passkeys via Credential Manager (WebSettingsCompat.setWebAuthenticationSupport(FOR_APP)) signs the client data with an origin of the form android:apk-key-hash:<base64url(sha256(signing-cert))> instead of the web origin. Since RPOrigins is hardcoded to [AppURL], Pocket ID responds with a generic error and self-hosted native apps can't complete passkey login inside their WebView — even with Digital Asset Links correctly published on the Pocket ID domain.

 Solution

 An optional ADDITIONAL_WEBAUTHN_ORIGINS env var (comma-separated) whose entries are appended to RPOrigins. Example:

 ADDITIONAL_WEBAUTHN_ORIGINS=android:apk-key-hash:H0TN8JZjHV581QfX6va0d8EsCdP7Tj-4lNdPSoMi0cI

 Default behavior is unchanged (unset → RPOrigins == [AppURL], exactly as today). No new dependencies; go-webauthn compares non-URL origins by exact string match, so android:apk-key-hash: origins work as-is.

 Running this patch in production against a Capacitor Android app: the full ceremony (Credential Manager prompt → assertion → Pocket ID verification → OIDC flow) works with this change and fails without it.
Happy to add a docs entry for the environment-variables page (separate repo) if this is accepted.

---
Once it's up, drop me the PR number if you want me to note it in the docs/memory. And with that, the entire Android + watch-sync stream is complete: shell, SSO with passkeys, sync with override protection and backfill, review workflow, infra fixes, and the upstream contribution staged. The only big thing left on the horizon is the iOS phase for misia — for another day.