### PR TITLE
chore: update Francis to beta 22

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -24,9 +24,9 @@ require (
 	github.com/go-webauthn/webauthn v0.17.4
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
-	github.com/italypaleale/francis v0.1.0-beta.21
+	github.com/italypaleale/francis v0.1.0-beta.22
 	github.com/italypaleale/go-kit v0.0.0-20260806152440-491aff6b42b5
-	github.com/italypaleale/go-sql-utils v0.3.4
+	github.com/italypaleale/go-sql-utils v0.3.5
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/jinzhu/copier v0.4.0
 	github.com/joho/godotenv v1.5.1

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -245,10 +245,14 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/italypaleale/francis v0.1.0-beta.21 h1:pYfPQVR9TIHihigrCmUiRYwHDfUoFHGoVQl5MUmysvg=
 github.com/italypaleale/francis v0.1.0-beta.21/go.mod h1:Ii6GFfm7AOt8kwWVsza2Tlq2PX17ofq/vJJaNsAoS3U=
+github.com/italypaleale/francis v0.1.0-beta.22 h1:ONOCfPEgvjy6fraAyKqX+wobTXIMZperWRruhj27jxQ=
+github.com/italypaleale/francis v0.1.0-beta.22/go.mod h1:qB+0OgLCTWw3/AmdHe30bN81TTo5BcI95kAwAJdLPuM=
 github.com/italypaleale/go-kit v0.0.0-20260806152440-491aff6b42b5 h1:bT2aB2nHewW4pHmVk36aRADW1owTDz1q1V5mRa5BCs0=
 github.com/italypaleale/go-kit v0.0.0-20260806152440-491aff6b42b5/go.mod h1:wg4UsIbsbtDiVqUjJdo/tO9lXo0OXBuwPOpSJ+u+1jI=
 github.com/italypaleale/go-sql-utils v0.3.4 h1:g9LGdXHhUKMC/3eufRYyY9mN9Vvi4PnLV+OXJwBKGt4=
 github.com/italypaleale/go-sql-utils v0.3.4/go.mod h1:STWS4qGjiGKt2tf9OdRUlf025FhKZvUA31siUOnejj0=
+github.com/italypaleale/go-sql-utils v0.3.5 h1:kkrhIo1tVJvcsjRc1kePWE9Cqdm26+Et5XZYSNmv764=
+github.com/italypaleale/go-sql-utils v0.3.5/go.mod h1:STWS4qGjiGKt2tf9OdRUlf025FhKZvUA31siUOnejj0=
 github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6 h1:D/V0gu4zQ3cL2WKeVNVM4r2gLxGGf6McLwgXzRTo2RQ=
 github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=


### PR DESCRIPTION
Includes go-sql-utils v0.3.5

These changes include improvements to health checks, that should improve reliability (see #1598)