### PR TITLE
fix: flaky update application image e2e test

### DIFF
--- a/tests/specs/application-configuration.spec.ts
+++ b/tests/specs/application-configuration.spec.ts
@@ -224,7 +224,20 @@ test.describe('Update application images', () => {
 		await page
 			.getByRole('button', { name: 'Reset to default Dark Mode Logo', exact: true })
 			.click();
+		const logoDeleteResponses = [true, false].map((light) =>
+			page.waitForResponse((response) => {
+				const url = new URL(response.url());
+				return (
+					response.request().method() === 'DELETE' &&
+					url.pathname === '/api/application-images/logo' &&
+					url.searchParams.get('light') === String(light)
+				);
+			})
+		);
 		await page.getByRole('button', { name: 'Save', exact: true }).nth(1).click();
+		for (const response of await Promise.all(logoDeleteResponses)) {
+			expect(response.status()).toBe(204);
+		}
 
 		await expect(page.locator('[data-type="success"]')).toHaveText(
 			'Images updated successfully. It may take a few minutes to update.'


### PR DESCRIPTION
Fixes e2e test failures like https://github.com/pocket-id/pocket-id/actions/runs/31771914920/job/94679431090 (unrelated from the PR, I've seen this fail in some cases)

Just need to wait for the DELETE to respond before verifying the logo is gone